### PR TITLE
Fix clap_fd type on Windows and clap_plugin::activate signature

### DIFF
--- a/src/ext/fd_support.rs
+++ b/src/ext/fd_support.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_FD_SUPPORT: *const c_char = b"clap.fd-support\0".as_ptr() as *const c_char;
 
 #[cfg(target_os = "windows")]
-pub type clap_fd = *mut c_void;
+pub type clap_fd = *mut ::core::ffi::c_void;
 #[cfg(not(target_os = "windows"))]
 pub type clap_fd = i32;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -41,7 +41,7 @@ pub struct clap_plugin {
         sample_rate: f64,
         min_frames_count: u32,
         max_frames_count: u32,
-    ),
+    ) -> bool,
     pub deactivate: unsafe extern "C" fn(plugin: *const clap_plugin),
     pub start_processing: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
     pub stop_processing: unsafe extern "C" fn(plugin: *const clap_plugin),


### PR DESCRIPTION
This PR fixes two small issues I found while working on the `rust-clap` wrapper :slightly_smiling_face: 

* The `clap_plugin::activate` actually returns `bool` in the C header, but didn't return anything in the bindings
* Fix the `clap_fd` type definition not building on Windows (due to the `c_void` type not being imported)