### PR TITLE
Fix clap_host_log::log declaration

### DIFF
--- a/src/ext/log.rs
+++ b/src/ext/log.rs
@@ -17,5 +17,5 @@ pub type clap_log_severity = i32;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct clap_host_log {
-    pub log: unsafe extern "C" fn(host: *const clap_host, msg: *const c_char),
+    pub log: unsafe extern "C" fn(host: *const clap_host, severity: clap_log_severity, msg: *const c_char),
 }


### PR DESCRIPTION
Another quick fix: the `clap_host_log::log` function was missing the severity parameter :slightly_smiling_face: 