### PR TITLE
Fix parameter type for plugin_params::get_info()

### DIFF
--- a/examples/gain.rs
+++ b/examples/gain.rs
@@ -94,6 +94,8 @@ mod plugin {
 
     pub unsafe extern "C" fn stop_processing(_plugin: *const clap_plugin) {}
 
+    pub unsafe extern "C" fn reset(_plugin: *const clap_plugin) {}
+
     pub unsafe extern "C" fn process(
         _plugin: *const clap_plugin,
         _process: *const clap_process,
@@ -160,6 +162,7 @@ mod factory {
                 deactivate: plugin::deactivate,
                 start_processing: plugin::start_processing,
                 stop_processing: plugin::stop_processing,
+                reset: plugin::reset,
                 process: plugin::process,
                 get_extension: plugin::get_extension,
                 on_main_thread: plugin::on_main_thread,

--- a/examples/gain.rs
+++ b/examples/gain.rs
@@ -16,7 +16,7 @@ mod params {
 
     pub unsafe extern "C" fn get_info(
         _plugin: *const clap_plugin,
-        _param_index: i32,
+        _param_index: u32,
         _param_info: *mut clap_param_info,
     ) -> bool {
         false

--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -38,7 +38,7 @@ pub struct clap_plugin_params {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
     pub get_info: unsafe extern "C" fn(
         plugin: *const clap_plugin,
-        param_index: i32,
+        param_index: u32,
         param_info: *mut clap_param_info,
     ) -> bool,
     pub get_value: unsafe extern "C" fn(


### PR DESCRIPTION
This obviously won't cause any problems in practice, but it should still be consistent with the API (which also returns an unsigned integer from the parameter count method):

https://github.com/free-audio/clap/blob/75f0c6d36ebc9c0fab291d95b782f42843ae1fd5/include/clap/ext/params.h#L174

I've also tacked on a commit to fix the example because I hadn't tried compiling that yet and it was missing a method added in CLAP 0.18.