### PR TITLE
Update for CLAP 0.25 and add all unimplemented factories and draft extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap-sys"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Micah Johnston <micah@glowcoil.com>"]
 edition = "2021"
 description = "Rust bindings for the CLAP audio plugin API"

--- a/src/converters/clap_converter.rs
+++ b/src/converters/clap_converter.rs
@@ -1,0 +1,46 @@
+use crate::{id::*, stream::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_CLAP_CONVERTER_FACTORY_ID: *const c_char =
+    b"clap.clap-converter-factory\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_clap_converter {
+    pub src_plugin_id: *const c_char,
+    pub dst_plugin_id: *const c_char,
+
+    pub convert_state: unsafe extern "C" fn(
+        converter: *const clap_clap_converter,
+        src: *const clap_istream,
+        dst: *const clap_ostream,
+    ) -> bool,
+    pub convert_normalized_value: unsafe extern "C" fn(
+        converter: *const clap_clap_converter,
+        src_param_id: clap_id,
+        src_normalized_value: f64,
+        dst_param_id: *mut clap_id,
+        dst_normalized_value: *mut f64,
+    ) -> bool,
+    pub convert_plain_value: unsafe extern "C" fn(
+        converter: *const clap_clap_converter,
+        src_param_id: clap_id,
+        src_plain_value: f64,
+        dst_param_id: *mut clap_id,
+        dst_plain_value: *mut f64,
+    ) -> bool,
+}
+
+unsafe impl Send for clap_clap_converter {}
+unsafe impl Sync for clap_clap_converter {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_clap_converter_factory {
+    pub count: unsafe extern "C" fn(factory: *const clap_clap_converter_factory) -> u32,
+    pub get: unsafe extern "C" fn(
+        factory: *const clap_clap_converter_factory,
+        index: u32,
+    ) -> *const clap_clap_converter,
+}

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -1,1 +1,2 @@
 pub mod clap_converter;
+pub mod vst2_converter;

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -1,0 +1,1 @@
+pub mod clap_converter;

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -1,2 +1,3 @@
 pub mod clap_converter;
 pub mod vst2_converter;
+pub mod vst3_converter;

--- a/src/converters/vst2_converter.rs
+++ b/src/converters/vst2_converter.rs
@@ -1,0 +1,47 @@
+use crate::{id::*, stream::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_VST2_CONVERTER_FACTORY_ID: *const c_char =
+    b"clap.vst2-converter-factory\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_vst2_converter {
+    pub vst2_plugin_id: u32,
+    pub vst2_plugin_name: *const c_char,
+    pub clap_plugin_id: *const c_char,
+
+    pub convert_state: unsafe extern "C" fn(
+        converter: *const clap_vst2_converter,
+        vst2: *const clap_istream,
+        clap: *const clap_ostream,
+    ) -> bool,
+    pub convert_normalized_value: unsafe extern "C" fn(
+        converter: *const clap_vst2_converter,
+        vst2_param_id: u32,
+        vst2_normalized_value: f64,
+        clap_param_id: *mut clap_id,
+        clap_normalized_value: *mut f64,
+    ) -> bool,
+    pub convert_plain_value: unsafe extern "C" fn(
+        converter: *const clap_vst2_converter,
+        vst2_param_id: u32,
+        vst2_plain_value: f64,
+        clap_param_id: *mut clap_id,
+        clap_plain_value: *mut f64,
+    ) -> bool,
+}
+
+unsafe impl Send for clap_vst2_converter {}
+unsafe impl Sync for clap_vst2_converter {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_vst2_converter_factory {
+    pub count: unsafe extern "C" fn(factory: *const clap_vst2_converter_factory) -> u32,
+    pub get: unsafe extern "C" fn(
+        factory: *const clap_vst2_converter_factory,
+        index: u32,
+    ) -> *const clap_vst2_converter,
+}

--- a/src/converters/vst3_converter.rs
+++ b/src/converters/vst3_converter.rs
@@ -1,0 +1,47 @@
+use crate::{id::*, stream::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_VST3_CONVERTER_FACTORY_ID: *const c_char =
+    b"clap.vst3-converter-factory\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_vst3_converter {
+    pub vst3_plugin_tuid: [i8; 16],
+    pub clap_plugin_id: *const c_char,
+
+    pub convert_state: unsafe extern "C" fn(
+        converter: *const clap_vst3_converter,
+        vst3_processor: *const clap_istream,
+        vst3_editor: *const clap_istream,
+        clap: *const clap_ostream,
+    ) -> bool,
+    pub convert_normalized_value: unsafe extern "C" fn(
+        converter: *const clap_vst3_converter,
+        vst3_param_id: u32,
+        vst3_normalized_value: f64,
+        clap_param_id: *mut clap_id,
+        clap_normalized_value: *mut f64,
+    ) -> bool,
+    pub convert_plain_value: unsafe extern "C" fn(
+        converter: *const clap_vst3_converter,
+        vst3_param_id: u32,
+        vst3_plain_value: f64,
+        clap_param_id: *mut clap_id,
+        clap_plain_value: *mut f64,
+    ) -> bool,
+}
+
+unsafe impl Send for clap_vst3_converter {}
+unsafe impl Sync for clap_vst3_converter {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_vst3_converter_factory {
+    pub count: unsafe extern "C" fn(factory: *const clap_vst3_converter_factory) -> u32,
+    pub get: unsafe extern "C" fn(
+        factory: *const clap_vst3_converter_factory,
+        index: u32,
+    ) -> *const clap_vst3_converter,
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -39,9 +39,10 @@ pub type clap_event_type = u16;
 #[derive(Copy, Clone)]
 pub struct clap_event_note {
     pub header: clap_event_header,
+    pub note_id: i32,
     pub port_index: i16,
-    pub key: i16,
     pub channel: i16,
+    pub key: i16,
     pub velocity: f64,
 }
 
@@ -60,9 +61,10 @@ pub type clap_note_expression = i32;
 pub struct clap_event_note_expression {
     pub header: clap_event_header,
     pub expression_id: clap_note_expression,
+    pub note_id: i32,
     pub port_index: i16,
-    pub key: i16,
     pub channel: i16,
+    pub key: i16,
     pub value: f64,
 }
 
@@ -72,9 +74,10 @@ pub struct clap_event_param_value {
     pub header: clap_event_header,
     pub param_id: clap_id,
     pub cookie: *mut c_void,
+    pub note_id: i32,
     pub port_index: i16,
-    pub key: i16,
     pub channel: i16,
+    pub key: i16,
     pub value: f64,
 }
 
@@ -87,9 +90,10 @@ pub struct clap_event_param_mod {
     pub header: clap_event_header,
     pub param_id: clap_id,
     pub cooke: *mut c_void,
+    pub note_id: i32,
     pub port_index: i16,
-    pub key: i16,
     pub channel: i16,
+    pub key: i16,
     pub amount: f64,
 }
 

--- a/src/ext/audio_ports_config.rs
+++ b/src/ext/audio_ports_config.rs
@@ -14,11 +14,11 @@ pub struct clap_audio_ports_config {
     pub input_port_count: u32,
     pub output_port_count: u32,
 
-    pub has_main_input_channel: bool,
+    pub has_main_input: bool,
     pub main_input_channel_count: u32,
     pub main_input_port_type: *const c_char,
 
-    pub has_main_output_channel: bool,
+    pub has_main_output: bool,
     pub main_output_channel_count: u32,
     pub main_output_port_type: *const c_char,
 }

--- a/src/ext/draft/ambisonic.rs
+++ b/src/ext/draft/ambisonic.rs
@@ -1,0 +1,40 @@
+use crate::{host::*, plugin::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_AMBISONIC: *const c_char = b"clap.ambisonic.draft/0\0".as_ptr() as *const c_char;
+
+pub const CLAP_PORT_AMBISONIC: *const c_char = b"ambisonic\0".as_ptr() as *const c_char;
+
+pub const CLAP_AMBISONIC_FUMA: u32 = 0;
+pub const CLAP_AMBISONIC_ACN: u32 = 1;
+
+pub const CLAP_AMBISONIC_NORMALIZATION_MAXN: u32 = 0;
+pub const CLAP_AMBISONIC_NORMALIZATION_SN3D: u32 = 1;
+pub const CLAP_AMBISONIC_NORMALIZATION_N3D: u32 = 2;
+pub const CLAP_AMBISONIC_NORMALIZATION_SN2D: u32 = 3;
+pub const CLAP_AMBISONIC_NORMALIZATION_N2D: u32 = 4;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_ambisonic_info {
+    pub ordering: u32,
+    pub normalization: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_ambisonic {
+    pub get_info: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        is_input: bool,
+        port_index: u32,
+        info: *mut clap_ambisonic_info,
+    ) -> bool,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_ambisonic {
+    pub changed: unsafe extern "C" fn(host: *const clap_host),
+}

--- a/src/ext/draft/check_for_update.rs
+++ b/src/ext/draft/check_for_update.rs
@@ -1,0 +1,35 @@
+use crate::host::*;
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_CHECK_FOR_UPDATE: *const c_char =
+    b"clap.check_for_update.draft/0\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_check_for_update_info {
+    pub version: *const c_char,
+    pub release_date: *const c_char,
+    pub url: *const c_char,
+    pub is_stable: bool,
+}
+
+unsafe impl Send for clap_check_for_update_info {}
+unsafe impl Sync for clap_check_for_update_info {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_check_for_update {
+    // FIXME: This `clap_host` should probably be a `clap_plugin`, see
+    //        https://github.com/free-audio/clap/issues/79
+    pub check: unsafe extern "C" fn(plugin: *const clap_host, include_beta: bool),
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_check_for_update {
+    pub on_new_version: unsafe extern "C" fn(
+        host: *const clap_host,
+        update_info: *const clap_check_for_update_info,
+    ),
+}

--- a/src/ext/draft/cv.rs
+++ b/src/ext/draft/cv.rs
@@ -1,0 +1,28 @@
+use crate::{host::*, plugin::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_CV: *const c_char = b"clap.cv.draft/0\0".as_ptr() as *const c_char;
+
+pub const CLAP_PORT_CV: *const c_char = b"cv\0".as_ptr() as *const c_char;
+
+pub const CLAP_CV_VALUE: u32 = 0;
+pub const CLAP_CV_GATE: u32 = 1;
+pub const CLAP_CV_PITCH: u32 = 2;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_cv {
+    pub get_channel_type: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        is_input: bool,
+        port_index: u32,
+        channel_index: u32,
+    ) -> u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_cv {
+    pub changed: unsafe extern "C" fn(host: *const clap_host),
+}

--- a/src/ext/draft/file_reference.rs
+++ b/src/ext/draft/file_reference.rs
@@ -1,0 +1,48 @@
+use crate::{hash::*, host::*, id::*, plugin::*, string_sizes::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_FILE_REFERENCE: *const c_char =
+    b"clap.file-reference.draft/0\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_file_reference {
+    pub resource_id: clap_id,
+    pub path: [c_char; CLAP_PATH_SIZE],
+    pub belongs_to_plugin_collection: bool,
+}
+
+unsafe impl Send for clap_file_reference {}
+unsafe impl Sync for clap_file_reference {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_file_reference {
+    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
+    pub get: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        index: u32,
+        file_reference: *mut clap_file_reference,
+    ) -> bool,
+    pub get_hash: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        resource_id: clap_id,
+        hash: clap_hash,
+        digest: *mut u8,
+        digest_size: u32,
+    ) -> bool,
+    pub update_path: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        resource_id: clap_id,
+        path: *const c_char,
+    ) -> bool,
+    pub save_resources: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_file_reference {
+    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub set_dirty: unsafe extern "C" fn(host: *const clap_host, resource_id: clap_id),
+}

--- a/src/ext/draft/midi_mappings.rs
+++ b/src/ext/draft/midi_mappings.rs
@@ -1,0 +1,40 @@
+use crate::{host::*, id::*, plugin::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_MIDI_MAPPINGS: *const c_char =
+    b"clap.midi-mappings.draft/0\0".as_ptr() as *const c_char;
+
+pub const CLAP_MIDI_MAPPING_CC7: clap_midi_mapping_type = 0;
+pub const CLAP_MIDI_MAPPING_CC14: clap_midi_mapping_type = 1;
+pub const CLAP_MIDI_MAPPING_RPN: clap_midi_mapping_type = 2;
+pub const CLAP_MIDI_MAPPING_NRPN: clap_midi_mapping_type = 3;
+
+// Not used or part of the enum in the current draft implementation, but we'll assume this was the
+// intention. Actually, these constants are also never reference anywhere...
+pub type clap_midi_mapping_type = i32;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_midi_mapping {
+    pub channel: i32,
+    pub number: i32,
+    pub param_id: clap_id,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_midi_mappings {
+    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
+    pub get: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        index: u32,
+        mapping: *mut clap_midi_mapping,
+    ) -> bool,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_midi_mappings {
+    pub changed: unsafe extern "C" fn(host: *const clap_host),
+}

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -4,3 +4,4 @@ pub mod cv;
 pub mod file_reference;
 pub mod midi_mappings;
 pub mod preset_load;
+pub mod quick_controls;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -6,3 +6,4 @@ pub mod midi_mappings;
 pub mod preset_load;
 pub mod quick_controls;
 pub mod surround;
+pub mod track_info;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -1,2 +1,3 @@
 pub mod ambisonic;
 pub mod check_for_update;
+pub mod cv;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -1,3 +1,4 @@
 pub mod ambisonic;
 pub mod check_for_update;
 pub mod cv;
+pub mod file_reference;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -8,3 +8,4 @@ pub mod quick_controls;
 pub mod surround;
 pub mod track_info;
 pub mod transport_control;
+pub mod tuning;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -9,3 +9,4 @@ pub mod surround;
 pub mod track_info;
 pub mod transport_control;
 pub mod tuning;
+pub mod voice_info;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -2,3 +2,4 @@ pub mod ambisonic;
 pub mod check_for_update;
 pub mod cv;
 pub mod file_reference;
+pub mod midi_mappings;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -1,1 +1,2 @@
 pub mod ambisonic;
+pub mod check_for_update;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -7,3 +7,4 @@ pub mod preset_load;
 pub mod quick_controls;
 pub mod surround;
 pub mod track_info;
+pub mod transport_control;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -5,3 +5,4 @@ pub mod file_reference;
 pub mod midi_mappings;
 pub mod preset_load;
 pub mod quick_controls;
+pub mod surround;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -1,0 +1,1 @@
+pub mod ambisonic;

--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -3,3 +3,4 @@ pub mod check_for_update;
 pub mod cv;
 pub mod file_reference;
 pub mod midi_mappings;
+pub mod preset_load;

--- a/src/ext/draft/preset_load.rs
+++ b/src/ext/draft/preset_load.rs
@@ -1,0 +1,12 @@
+use crate::plugin::*;
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_PRESET_LOAD: *const c_char =
+    b"clap.preset-load.draft/0\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_preset_load {
+    pub from_file: unsafe extern "C" fn(plugin: *const clap_plugin, path: *const c_char) -> bool,
+}

--- a/src/ext/draft/quick_controls.rs
+++ b/src/ext/draft/quick_controls.rs
@@ -1,0 +1,45 @@
+use crate::{hash::*, host::*, id::*, plugin::*, string_sizes::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_QUICK_CONTROLS: *const c_char =
+    b"clap.quick-controls.draft/0\0".as_ptr() as *const c_char;
+
+pub const CLAP_QUICK_CONTROLS_COUNT: usize = 8;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_quick_controls_page {
+    pub id: clap_id,
+    pub name: [c_char; CLAP_NAME_SIZE],
+    pub keywords: [c_char; CLAP_KEYWORDS_SIZE],
+    pub param_ids: [clap_id; CLAP_QUICK_CONTROLS_COUNT],
+}
+
+unsafe impl Send for clap_quick_controls_page {}
+unsafe impl Sync for clap_quick_controls_page {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_quick_controls {
+    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
+    pub get: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        page_index: u32,
+        page: *mut clap_quick_controls_page,
+    ) -> bool,
+    pub select: unsafe extern "C" fn(plugin: *const clap_plugin, page_id: clap_id),
+    pub get_selected: unsafe extern "C" fn(plugin: *const clap_plugin) -> clap_id,
+}
+
+pub const CLAP_QUICK_CONTROLS_PAGES_CHANGED: clap_quick_controls_changed_flags = 1 << 0;
+pub const CLAP_QUICK_CONTROLS_SELECTED_PAGE_CHANGED: clap_quick_controls_changed_flags = 1 << 1;
+
+pub type clap_quick_controls_changed_flags = u32;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_quick_controls {
+    pub changed:
+        unsafe extern "C" fn(host: *const clap_host, flags: clap_quick_controls_changed_flags),
+}

--- a/src/ext/draft/surround.rs
+++ b/src/ext/draft/surround.rs
@@ -1,0 +1,51 @@
+use crate::{host::*, plugin::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_SURROUND: *const c_char = b"clap.surround.draft/1\0".as_ptr() as *const c_char;
+
+pub const CLAP_PORT_SURROUND: *const c_char = b"surround\0".as_ptr() as *const c_char;
+
+pub const CLAP_SURROUND_FL: u32 = 0;
+pub const CLAP_SURROUND_FR: u32 = 1;
+pub const CLAP_SURROUND_FC: u32 = 2;
+pub const CLAP_SURROUND_LFE: u32 = 3;
+pub const CLAP_SURROUND_BL: u32 = 4;
+pub const CLAP_SURROUND_BR: u32 = 5;
+pub const CLAP_SURROUND_FLC: u32 = 6;
+pub const CLAP_SURROUND_FRC: u32 = 7;
+pub const CLAP_SURROUND_BC: u32 = 8;
+pub const CLAP_SURROUND_SL: u32 = 9;
+pub const CLAP_SURROUND_SR: u32 = 10;
+pub const CLAP_SURROUND_TC: u32 = 11;
+pub const CLAP_SURROUND_TFL: u32 = 12;
+pub const CLAP_SURROUND_TFC: u32 = 13;
+pub const CLAP_SURROUND_TFR: u32 = 14;
+pub const CLAP_SURROUND_TBL: u32 = 15;
+pub const CLAP_SURROUND_TBC: u32 = 16;
+pub const CLAP_SURROUND_TBR: u32 = 17;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_surround {
+    pub get_channel_map: unsafe extern "C" fn(
+        plugin: *const clap_plugin,
+        is_input: bool,
+        port_index: u32,
+        channel_map: *mut u8,
+        channel_map_capacity: u32,
+    ) -> u32,
+    pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_surround {
+    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub get_preferred_channel_map: unsafe extern "C" fn(
+        plugin: *const clap_host,
+        channel_map: *mut u8,
+        channel_map_capacity: u32,
+        channel_count: *mut u32,
+    ),
+}

--- a/src/ext/draft/track_info.rs
+++ b/src/ext/draft/track_info.rs
@@ -1,0 +1,34 @@
+use crate::{color::*, host::*, id::*, plugin::*, string_sizes::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_TRACK_INFO: *const c_char =
+    b"clap.track-info.draft/0\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_track_info {
+    pub id: clap_id,
+    pub index: i32,
+    pub name: [c_char; CLAP_NAME_SIZE],
+    pub path: [c_char; CLAP_MODULE_SIZE],
+    pub channel_count: i32,
+    pub audio_port_type: *const c_char,
+    pub color: clap_color,
+    pub is_return_track: bool,
+}
+
+unsafe impl Send for clap_track_info {}
+unsafe impl Sync for clap_track_info {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_track_info {
+    pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_track_info {
+    pub get: unsafe extern "C" fn(host: *const clap_host, info: *mut clap_track_info) -> bool,
+}

--- a/src/ext/draft/transport_control.rs
+++ b/src/ext/draft/transport_control.rs
@@ -1,0 +1,23 @@
+use crate::{fixedpoint::*, host::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_TRANSPORT_CONTROL: *const c_char =
+    b"clap.transport-control.draft/0\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_transport_control {
+    pub request_start: unsafe extern "C" fn(host: *const clap_host),
+    pub request_stop: unsafe extern "C" fn(host: *const clap_host),
+    pub request_continue: unsafe extern "C" fn(host: *const clap_host),
+    pub request_pause: unsafe extern "C" fn(host: *const clap_host),
+    pub request_toggle_play: unsafe extern "C" fn(host: *const clap_host),
+    pub request_jump: unsafe extern "C" fn(host: *const clap_host, position: clap_beattime),
+    pub request_loop_region:
+        unsafe extern "C" fn(host: *const clap_host, start: clap_beattime, duration: clap_beattime),
+    pub request_toggle_loop: unsafe extern "C" fn(host: *const clap_host),
+    pub request_enable_loop: unsafe extern "C" fn(host: *const clap_host, is_enabled: bool),
+    pub request_record: unsafe extern "C" fn(host: *const clap_host, is_recording: bool),
+    pub request_toggle_record: unsafe extern "C" fn(host: *const clap_host),
+}

--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -24,9 +24,11 @@ pub struct clap_tuning_info {
 unsafe impl Send for clap_tuning_info {}
 unsafe impl Sync for clap_tuning_info {}
 
+// NOTE: `clap_client_tuning` is almost certainly a typo and it should be `clap_plugin_tuning`
+//       instead
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct clap_plugin_tuning {
+pub struct clap_client_tuning {
     pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
 }
 

--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -1,0 +1,55 @@
+use crate::{events::*, host::*, id::*, plugin::*, string_sizes::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_TUNING: *const c_char = b"clap.tuning.draft/2\0".as_ptr() as *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_event_tuning {
+    pub header: clap_event_header,
+    pub port_index: i16,
+    pub channel: i16,
+    pub tunning_id: clap_id,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_tuning_info {
+    pub tuning_id: clap_id,
+    pub name: [c_char; CLAP_NAME_SIZE],
+    pub is_dynamic: bool,
+}
+
+unsafe impl Send for clap_tuning_info {}
+unsafe impl Sync for clap_tuning_info {}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_tuning {
+    pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_tuning {
+    pub get_relative: unsafe extern "C" fn(
+        host: *const clap_host,
+        tuning_id: clap_id,
+        channel: i32,
+        key: i32,
+        sample_offset: u32,
+    ) -> f64,
+    pub should_play: unsafe extern "C" fn(
+        host: *const clap_host,
+        tuning_id: clap_id,
+        channel: i32,
+        key: i32,
+    ) -> bool,
+    pub get_tuning_count: unsafe extern "C" fn(host: *const clap_host) -> u32,
+    pub get_info: unsafe extern "C" fn(
+        host: *const clap_host,
+        tuning_index: u32,
+        info: *mut clap_tuning_info,
+    ) -> bool,
+}

--- a/src/ext/draft/voice_info.rs
+++ b/src/ext/draft/voice_info.rs
@@ -1,0 +1,28 @@
+use crate::{host::*, plugin::*};
+
+use std::os::raw::c_char;
+
+pub const CLAP_EXT_VOICE_INFO: *const c_char =
+    b"clap.voice-info.draft/0\0".as_ptr() as *const c_char;
+
+pub const CLAP_VOICE_INFO_SUPPORTS_OVERLAPPING_NOTES: u64 = 1 << 0;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_voice_info {
+    pub voice_count: u32,
+    pub voice_capacity: u32,
+    pub flags: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_plugin_voice_info {
+    pub get: unsafe extern "C" fn(plugin: *const clap_plugin, info: *mut clap_voice_info) -> bool,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct clap_host_voice_info {
+    pub changed: unsafe extern "C" fn(host: *const clap_host),
+}

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -1,3 +1,5 @@
+pub mod draft;
+
 pub mod audio_ports;
 pub mod audio_ports_config;
 pub mod event_filter;

--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -11,14 +11,16 @@ pub const CLAP_PARAM_IS_HIDDEN: clap_param_info_flags = 1 << 2;
 pub const CLAP_PARAM_IS_READONLY: clap_param_info_flags = 1 << 3;
 pub const CLAP_PARAM_IS_BYPASS: clap_param_info_flags = 1 << 4;
 pub const CLAP_PARAM_IS_AUTOMATABLE: clap_param_info_flags = 1 << 5;
-pub const CLAP_PARAM_IS_AUTOMATABLE_PER_NOTE: clap_param_info_flags = 1 << 6;
-pub const CLAP_PARAM_IS_AUTOMATABLE_PER_CHANNEL: clap_param_info_flags = 1 << 7;
-pub const CLAP_PARAM_IS_AUTOMATABLE_PER_PORT: clap_param_info_flags = 1 << 8;
-pub const CLAP_PARAM_IS_MODULATABLE: clap_param_info_flags = 1 << 9;
-pub const CLAP_PARAM_IS_MODULATABLE_PER_NOTE: clap_param_info_flags = 1 << 10;
-pub const CLAP_PARAM_IS_MODULATABLE_PER_CHANNEL: clap_param_info_flags = 1 << 11;
-pub const CLAP_PARAM_IS_MODULATABLE_PER_PORT: clap_param_info_flags = 1 << 12;
-pub const CLAP_PARAM_REQUIRES_PROCESS: clap_param_info_flags = 1 << 13;
+pub const CLAP_PARAM_IS_AUTOMATABLE_PER_NOTE_ID: clap_param_info_flags = 1 << 6;
+pub const CLAP_PARAM_IS_AUTOMATABLE_PER_KEY: clap_param_info_flags = 1 << 7;
+pub const CLAP_PARAM_IS_AUTOMATABLE_PER_CHANNEL: clap_param_info_flags = 1 << 8;
+pub const CLAP_PARAM_IS_AUTOMATABLE_PER_PORT: clap_param_info_flags = 1 << 9;
+pub const CLAP_PARAM_IS_MODULATABLE: clap_param_info_flags = 1 << 10;
+pub const CLAP_PARAM_IS_MODULATABLE_PER_NOTE_ID: clap_param_info_flags = 1 << 11;
+pub const CLAP_PARAM_IS_MODULATABLE_PER_KEY: clap_param_info_flags = 1 << 12;
+pub const CLAP_PARAM_IS_MODULATABLE_PER_CHANNEL: clap_param_info_flags = 1 << 13;
+pub const CLAP_PARAM_IS_MODULATABLE_PER_PORT: clap_param_info_flags = 1 << 14;
+pub const CLAP_PARAM_REQUIRES_PROCESS: clap_param_info_flags = 1 << 15;
 
 pub type clap_param_info_flags = u32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod audio_buffer;
 pub mod color;
+pub mod converters;
 pub mod entry;
 pub mod events;
 pub mod ext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 #![allow(non_camel_case_types)]
 
+pub mod converters;
+pub mod ext;
+
 pub mod audio_buffer;
 pub mod color;
-pub mod converters;
 pub mod entry;
 pub mod events;
-pub mod ext;
 pub mod fixedpoint;
 pub mod hash;
 pub mod host;

--- a/src/version.rs
+++ b/src/version.rs
@@ -7,7 +7,7 @@ pub struct clap_version {
 }
 
 pub const CLAP_VERSION_MAJOR: u32 = 0;
-pub const CLAP_VERSION_MINOR: u32 = 24;
+pub const CLAP_VERSION_MINOR: u32 = 25;
 pub const CLAP_VERSION_REVISION: u32 = 0;
 
 pub const CLAP_VERSION: clap_version = clap_version {


### PR DESCRIPTION
Based on this diff: https://github.com/free-audio/clap/compare/32f19b54d3e9fb21c7d6758dff258ea1f7e04292...cf2bdb1380d97dcf6d69ba603c444b1981efcd3d

I've also implemented all of the factories and draft extensions from the CLAP API that were missing here since I wanted to use a couple of those. If you want I can split this up into two PRs.