### PR TITLE
Update for CLAP 1.0.1

### DIFF
--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -24,11 +24,9 @@ pub struct clap_tuning_info {
 unsafe impl Send for clap_tuning_info {}
 unsafe impl Sync for clap_tuning_info {}
 
-// NOTE: `clap_client_tuning` is almost certainly a typo and it should be `clap_plugin_tuning`
-//       instead
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct clap_client_tuning {
+pub struct clap_plugin_tuning_t {
     pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,7 +8,7 @@ pub struct clap_version {
 
 pub const CLAP_VERSION_MAJOR: u32 = 1;
 pub const CLAP_VERSION_MINOR: u32 = 0;
-pub const CLAP_VERSION_REVISION: u32 = 0;
+pub const CLAP_VERSION_REVISION: u32 = 1;
 
 pub const CLAP_VERSION: clap_version = clap_version {
     major: CLAP_VERSION_MAJOR,


### PR DESCRIPTION
Based on https://github.com/free-audio/clap/blob/d8c3b19f7b4a1b36c3025a22efa08deb49d7c0cb/include/clap/events.h

For readability's sake I decided to leave the `clap_event_type` type alias in. Ours was already the correct type compared to the incorrect one in CLAP's `event.h`, and we do similar things for other anonymous enums that also don't have a typedef.