### PR TITLE
Derive Debug for everything

### DIFF
--- a/src/audio_buffer.rs
+++ b/src/audio_buffer.rs
@@ -1,5 +1,5 @@
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_audio_buffer {
     pub data32: *const *const f32,
     pub data64: *const *const f64,

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,5 +1,5 @@
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_color {
     pub alpha: u8,
     pub red: u8,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 use std::os::raw::c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_entry {
     pub clap_version: clap_version,
     pub init: unsafe extern "C" fn(plugin_path: *const c_char) -> bool,

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,7 +3,7 @@ use crate::{fixedpoint::*, id::*};
 use std::ffi::c_void;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_header {
     pub size: u32,
     pub time: u32,
@@ -36,7 +36,7 @@ pub const CLAP_EVENT_MIDI2: clap_event_type = 12;
 pub type clap_event_type = u16;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_note {
     pub header: clap_event_header,
     pub note_id: i32,
@@ -57,7 +57,7 @@ pub const CLAP_NOTE_EXPRESSION_PRESSURE: clap_note_expression = 6;
 pub type clap_note_expression = i32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_note_expression {
     pub header: clap_event_header,
     pub expression_id: clap_note_expression,
@@ -69,7 +69,7 @@ pub struct clap_event_note_expression {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_param_value {
     pub header: clap_event_header,
     pub param_id: clap_id,
@@ -85,7 +85,7 @@ unsafe impl Send for clap_event_param_value {}
 unsafe impl Sync for clap_event_param_value {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_param_mod {
     pub header: clap_event_header,
     pub param_id: clap_id,
@@ -101,7 +101,7 @@ unsafe impl Send for clap_event_param_mod {}
 unsafe impl Sync for clap_event_param_mod {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_param_gesture {
     pub header: clap_event_header,
     pub param_id: clap_id,
@@ -119,7 +119,7 @@ pub const CLAP_TRANSPORT_IS_WITHIN_PRE_ROLL: clap_transport_flags = 1 << 7;
 pub type clap_transport_flags = u32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_transport {
     pub header: clap_event_header,
     pub flags: clap_transport_flags,
@@ -138,7 +138,7 @@ pub struct clap_event_transport {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_midi {
     pub header: clap_event_header,
     pub port_index: u16,
@@ -146,7 +146,7 @@ pub struct clap_event_midi {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_midi_sysex {
     pub header: clap_event_header,
     pub port_index: u16,
@@ -158,7 +158,7 @@ unsafe impl Send for clap_event_midi_sysex {}
 unsafe impl Sync for clap_event_midi_sysex {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_midi2 {
     pub header: clap_event_header,
     pub port_index: u16,
@@ -166,7 +166,7 @@ pub struct clap_event_midi2 {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_input_events {
     pub ctx: *mut c_void,
     pub size: unsafe extern "C" fn(list: *const clap_input_events) -> u32,
@@ -180,7 +180,7 @@ unsafe impl Send for clap_input_events {}
 unsafe impl Sync for clap_input_events {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_output_events {
     pub ctx: *mut c_void,
     pub try_push: unsafe extern "C" fn(

--- a/src/ext/audio_ports.rs
+++ b/src/ext/audio_ports.rs
@@ -13,7 +13,7 @@ pub const CLAP_AUDIO_PORT_PREFERS_64BITS: u32 = 1 << 2;
 pub const CLAP_AUDIO_PORT_REQUIRES_COMMON_SAMPLE_SIZE: u32 = 1 << 3;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_audio_port_info {
     pub id: clap_id,
     pub name: [c_char; CLAP_NAME_SIZE],
@@ -27,7 +27,7 @@ unsafe impl Send for clap_audio_port_info {}
 unsafe impl Sync for clap_audio_port_info {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_audio_ports {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin, is_input: bool) -> u32,
     pub get: unsafe extern "C" fn(
@@ -46,7 +46,7 @@ pub const CLAP_AUDIO_PORTS_RESCAN_IN_PLACE_PAIR: u32 = 1 << 4;
 pub const CLAP_AUDIO_PORTS_RESCAN_LIST: u32 = 1 << 5;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_audio_ports {
     pub is_rescan_flag_supported: unsafe extern "C" fn(host: *const clap_host, flag: u32) -> bool,
     pub rescan: unsafe extern "C" fn(host: *const clap_host, flags: u32),

--- a/src/ext/audio_ports_config.rs
+++ b/src/ext/audio_ports_config.rs
@@ -6,7 +6,7 @@ pub const CLAP_EXT_AUDIO_PORTS_CONFIG: *const c_char =
     b"clap.audio-ports-config\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_audio_ports_config {
     pub id: clap_id,
     pub name: [c_char; CLAP_NAME_SIZE],
@@ -27,7 +27,7 @@ unsafe impl Send for clap_audio_ports_config {}
 unsafe impl Sync for clap_audio_ports_config {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_audio_ports_config {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
     pub get: unsafe extern "C" fn(
@@ -39,7 +39,7 @@ pub struct clap_plugin_audio_ports_config {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_audio_ports_config {
     pub rescan: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/draft/ambisonic.rs
+++ b/src/ext/draft/ambisonic.rs
@@ -16,14 +16,14 @@ pub const CLAP_AMBISONIC_NORMALIZATION_SN2D: u32 = 3;
 pub const CLAP_AMBISONIC_NORMALIZATION_N2D: u32 = 4;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_ambisonic_info {
     pub ordering: u32,
     pub normalization: u32,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_ambisonic {
     pub get_info: unsafe extern "C" fn(
         plugin: *const clap_plugin,
@@ -34,7 +34,7 @@ pub struct clap_plugin_ambisonic {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_ambisonic {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/draft/check_for_update.rs
+++ b/src/ext/draft/check_for_update.rs
@@ -6,7 +6,7 @@ pub const CLAP_EXT_CHECK_FOR_UPDATE: *const c_char =
     b"clap.check_for_update.draft/0\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_check_for_update_info {
     pub version: *const c_char,
     pub release_date: *const c_char,
@@ -18,13 +18,13 @@ unsafe impl Send for clap_check_for_update_info {}
 unsafe impl Sync for clap_check_for_update_info {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_check_for_update {
     pub check: unsafe extern "C" fn(plugin: *const clap_plugin, include_preview: bool),
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_check_for_update {
     pub on_new_version: unsafe extern "C" fn(
         host: *const clap_host,

--- a/src/ext/draft/cv.rs
+++ b/src/ext/draft/cv.rs
@@ -11,7 +11,7 @@ pub const CLAP_CV_GATE: u32 = 1;
 pub const CLAP_CV_PITCH: u32 = 2;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_cv {
     pub get_channel_type: unsafe extern "C" fn(
         plugin: *const clap_plugin,
@@ -23,7 +23,7 @@ pub struct clap_plugin_cv {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_cv {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/draft/file_reference.rs
+++ b/src/ext/draft/file_reference.rs
@@ -6,7 +6,7 @@ pub const CLAP_EXT_FILE_REFERENCE: *const c_char =
     b"clap.file-reference.draft/0\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_file_reference {
     pub resource_id: clap_id,
     pub belongs_to_plugin_collection: bool,
@@ -19,7 +19,7 @@ unsafe impl Send for clap_file_reference {}
 unsafe impl Sync for clap_file_reference {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_file_reference {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
     pub get: unsafe extern "C" fn(
@@ -46,7 +46,7 @@ pub struct clap_plugin_file_reference {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_file_reference {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
     pub set_dirty: unsafe extern "C" fn(host: *const clap_host, resource_id: clap_id),

--- a/src/ext/draft/midi_mappings.rs
+++ b/src/ext/draft/midi_mappings.rs
@@ -15,7 +15,7 @@ pub const CLAP_MIDI_MAPPING_NRPN: clap_midi_mapping_type = 3;
 pub type clap_midi_mapping_type = i32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_midi_mapping {
     pub channel: i32,
     pub number: i32,
@@ -23,7 +23,7 @@ pub struct clap_midi_mapping {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_midi_mappings {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
     pub get: unsafe extern "C" fn(
@@ -34,7 +34,7 @@ pub struct clap_plugin_midi_mappings {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_midi_mappings {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/draft/preset_load.rs
+++ b/src/ext/draft/preset_load.rs
@@ -6,7 +6,7 @@ pub const CLAP_EXT_PRESET_LOAD: *const c_char =
     b"clap.preset-load.draft/0\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_preset_load {
     pub from_file: unsafe extern "C" fn(plugin: *const clap_plugin, path: *const c_char) -> bool,
 }

--- a/src/ext/draft/quick_controls.rs
+++ b/src/ext/draft/quick_controls.rs
@@ -8,7 +8,7 @@ pub const CLAP_EXT_QUICK_CONTROLS: *const c_char =
 pub const CLAP_QUICK_CONTROLS_COUNT: usize = 8;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_quick_controls_page {
     pub id: clap_id,
     pub name: [c_char; CLAP_NAME_SIZE],
@@ -19,7 +19,7 @@ unsafe impl Send for clap_quick_controls_page {}
 unsafe impl Sync for clap_quick_controls_page {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_quick_controls {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
     pub get: unsafe extern "C" fn(
@@ -30,7 +30,7 @@ pub struct clap_plugin_quick_controls {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_quick_controls {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
     pub suggest_page: unsafe extern "C" fn(host: *const clap_host, page_id: clap_id),

--- a/src/ext/draft/surround.rs
+++ b/src/ext/draft/surround.rs
@@ -26,7 +26,7 @@ pub const CLAP_SURROUND_TBC: u32 = 16;
 pub const CLAP_SURROUND_TBR: u32 = 17;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_surround {
     pub get_channel_map: unsafe extern "C" fn(
         plugin: *const clap_plugin,
@@ -39,7 +39,7 @@ pub struct clap_plugin_surround {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_surround {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
     pub get_preferred_channel_map: unsafe extern "C" fn(

--- a/src/ext/draft/track_info.rs
+++ b/src/ext/draft/track_info.rs
@@ -6,7 +6,7 @@ pub const CLAP_EXT_TRACK_INFO: *const c_char =
     b"clap.track-info.draft/0\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_track_info {
     pub id: clap_id,
     pub index: i32,
@@ -22,13 +22,13 @@ unsafe impl Send for clap_track_info {}
 unsafe impl Sync for clap_track_info {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_track_info {
     pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_track_info {
     pub get: unsafe extern "C" fn(host: *const clap_host, info: *mut clap_track_info) -> bool,
 }

--- a/src/ext/draft/transport_control.rs
+++ b/src/ext/draft/transport_control.rs
@@ -6,7 +6,7 @@ pub const CLAP_EXT_TRANSPORT_CONTROL: *const c_char =
     b"clap.transport-control.draft/0\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_transport_control {
     pub request_start: unsafe extern "C" fn(host: *const clap_host),
     pub request_stop: unsafe extern "C" fn(host: *const clap_host),

--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_TUNING: *const c_char = b"clap.tuning.draft/2\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_event_tuning {
     pub header: clap_event_header,
     pub port_index: i16,
@@ -14,7 +14,7 @@ pub struct clap_event_tuning {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_tuning_info {
     pub tuning_id: clap_id,
     pub name: [c_char; CLAP_NAME_SIZE],
@@ -25,13 +25,13 @@ unsafe impl Send for clap_tuning_info {}
 unsafe impl Sync for clap_tuning_info {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_tuning_t {
     pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_tuning {
     pub get_relative: unsafe extern "C" fn(
         host: *const clap_host,

--- a/src/ext/draft/voice_info.rs
+++ b/src/ext/draft/voice_info.rs
@@ -8,7 +8,7 @@ pub const CLAP_EXT_VOICE_INFO: *const c_char =
 pub const CLAP_VOICE_INFO_SUPPORTS_OVERLAPPING_NOTES: u64 = 1 << 0;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_voice_info {
     pub voice_count: u32,
     pub voice_capacity: u32,
@@ -16,13 +16,13 @@ pub struct clap_voice_info {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_voice_info {
     pub get: unsafe extern "C" fn(plugin: *const clap_plugin, info: *mut clap_voice_info) -> bool,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_voice_info {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/event_registry.rs
+++ b/src/ext/event_registry.rs
@@ -6,7 +6,7 @@ pub const CLAP_EXT_EVENT_REGISTRY: *const c_char =
     b"clap.event-registry\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_event_registry {
     pub query: unsafe extern "C" fn(
         host: *const clap_host,

--- a/src/ext/gui.rs
+++ b/src/ext/gui.rs
@@ -15,7 +15,7 @@ pub type clap_nsview = *mut c_void;
 pub type clap_xwnd = c_ulong;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_window {
     pub api: *const c_char,
     pub specific: clap_window_handle,
@@ -26,7 +26,7 @@ unsafe impl Sync for clap_window {}
 
 /// Defined as an anonymous union in [`clap_window`] in the C-version.
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub union clap_window_handle {
     pub cocoa: clap_nsview,
     pub x11: clap_xwnd,
@@ -38,7 +38,7 @@ unsafe impl Send for clap_window_handle {}
 unsafe impl Sync for clap_window_handle {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_gui_resize_hints {
     pub can_resize_horizontally: bool,
     pub can_resize_vertically: bool,
@@ -48,7 +48,7 @@ pub struct clap_gui_resize_hints {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_gui {
     pub is_api_supported: unsafe extern "C" fn(
         plugin: *const clap_plugin,
@@ -85,7 +85,7 @@ pub struct clap_plugin_gui {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_gui {
     pub resize_hints_changed: unsafe extern "C" fn(host: *const clap_host),
     pub request_resize:

--- a/src/ext/latency.rs
+++ b/src/ext/latency.rs
@@ -5,13 +5,13 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_LATENCY: *const c_char = b"clap.latency\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_latency {
     pub get: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_latency {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/log.rs
+++ b/src/ext/log.rs
@@ -15,7 +15,7 @@ pub const CLAP_LOG_PLUGIN_MISBEHAVING: clap_log_severity = 6;
 pub type clap_log_severity = i32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_log {
     pub log: unsafe extern "C" fn(
         host: *const clap_host,

--- a/src/ext/note_name.rs
+++ b/src/ext/note_name.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_NOTE_NAME: *const c_char = b"clap.note-name\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_note_name {
     pub name: [c_char; CLAP_NAME_SIZE],
     pub port: i16,
@@ -14,7 +14,7 @@ pub struct clap_note_name {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_note_name {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
     pub get: unsafe extern "C" fn(
@@ -25,7 +25,7 @@ pub struct clap_plugin_note_name {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_note_name {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/note_ports.rs
+++ b/src/ext/note_ports.rs
@@ -12,7 +12,7 @@ pub const CLAP_NOTE_DIALECT_MIDI2: clap_note_dialect = 1 << 3;
 pub type clap_note_dialect = u32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_note_port_info {
     pub id: clap_id,
     pub supported_dialects: clap_note_dialect,
@@ -21,7 +21,7 @@ pub struct clap_note_port_info {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_note_ports {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin, is_input: bool) -> u32,
     pub get: unsafe extern "C" fn(
@@ -36,7 +36,7 @@ pub const CLAP_NOTE_PORTS_RESCAN_ALL: u32 = 1 << 0;
 pub const CLAP_NOTE_PORTS_RESCAN_NAMES: u32 = 1 << 1;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_note_ports {
     pub supported_dialects: unsafe extern "C" fn(host: *const clap_host) -> clap_note_dialect,
     pub rescan: unsafe extern "C" fn(host: *const clap_host, flags: u32),

--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -25,7 +25,7 @@ pub const CLAP_PARAM_REQUIRES_PROCESS: clap_param_info_flags = 1 << 15;
 pub type clap_param_info_flags = u32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_param_info {
     pub id: clap_id,
     pub flags: clap_param_info_flags,
@@ -41,7 +41,7 @@ unsafe impl Send for clap_param_info {}
 unsafe impl Sync for clap_param_info {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_params {
     pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
     pub get_info: unsafe extern "C" fn(
@@ -88,7 +88,7 @@ pub const CLAP_PARAM_CLEAR_MODULATIONS: clap_param_clear_flags = 1 << 2;
 pub type clap_param_clear_flags = u32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_params {
     pub rescan: unsafe extern "C" fn(host: *const clap_host, flags: clap_param_rescan_flags),
     pub clear: unsafe extern "C" fn(

--- a/src/ext/posix_fd_support.rs
+++ b/src/ext/posix_fd_support.rs
@@ -11,14 +11,14 @@ pub const CLAP_POSIX_FD_ERROR: clap_posix_fd_flags = 1 << 2;
 pub type clap_posix_fd_flags = u32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_posix_fd_support {
     pub on_fd:
         unsafe extern "C" fn(plugin: *const clap_plugin, fd: i32, flags: clap_posix_fd_flags),
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_posix_fd_support {
     pub register_fd:
         unsafe extern "C" fn(host: *const clap_host, fd: i32, flags: clap_posix_fd_flags) -> bool,

--- a/src/ext/render.rs
+++ b/src/ext/render.rs
@@ -10,7 +10,7 @@ pub const CLAP_RENDER_OFFLINE: clap_plugin_render_mode = 1;
 pub type clap_plugin_render_mode = i32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_render {
     pub has_hard_realtime_requirement: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
     pub set:

--- a/src/ext/state.rs
+++ b/src/ext/state.rs
@@ -5,14 +5,14 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_STATE: *const c_char = b"clap.state\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_state {
     pub save: unsafe extern "C" fn(plugin: *const clap_plugin, stream: *const clap_ostream) -> bool,
     pub load: unsafe extern "C" fn(plugin: *const clap_plugin, stream: *const clap_istream) -> bool,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_state {
     pub mark_dirty: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/tail.rs
+++ b/src/ext/tail.rs
@@ -5,13 +5,13 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_TAIL: *const c_char = b"clap.tail\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_tail {
     pub get: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_tail {
     pub changed: unsafe extern "C" fn(host: *const clap_host),
 }

--- a/src/ext/thread_check.rs
+++ b/src/ext/thread_check.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_THREAD_CHECK: *const c_char = b"clap.thread-check\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_thread_check {
     pub is_main_thread: unsafe extern "C" fn(host: *const clap_host) -> bool,
     pub is_audio_thread: unsafe extern "C" fn(host: *const clap_host) -> bool,

--- a/src/ext/thread_pool.rs
+++ b/src/ext/thread_pool.rs
@@ -5,13 +5,13 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_THREAD_POOL: *const c_char = b"clap.thread-pool\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_thread_pool {
     pub exec: unsafe extern "C" fn(plugin: *const clap_plugin, task_index: u32),
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_thread_pool {
     pub request_exec: unsafe extern "C" fn(host: *const clap_host, num_tasks: u32) -> bool,
 }

--- a/src/ext/timer_support.rs
+++ b/src/ext/timer_support.rs
@@ -5,13 +5,13 @@ use std::os::raw::c_char;
 pub const CLAP_EXT_TIMER_SUPPORT: *const c_char = b"clap.timer-support\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_timer_support {
     pub on_timer: unsafe extern "C" fn(plugin: *const clap_plugin, timer_id: clap_id),
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host_timer_support {
     pub register_timer: unsafe extern "C" fn(
         host: *const clap_host,

--- a/src/host.rs
+++ b/src/host.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 use std::os::raw::c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_host {
     pub clap_version: clap_version,
     pub host_data: *mut c_void,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 use std::os::raw::c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_descriptor {
     pub clap_version: clap_version,
     pub id: *const c_char,
@@ -22,7 +22,7 @@ unsafe impl Send for clap_plugin_descriptor {}
 unsafe impl Sync for clap_plugin_descriptor {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin {
     pub desc: *const clap_plugin_descriptor,
     pub plugin_data: *mut c_void,

--- a/src/plugin_factory.rs
+++ b/src/plugin_factory.rs
@@ -6,7 +6,7 @@ pub const CLAP_PLUGIN_FACTORY_ID: *const c_char =
     b"clap.plugin-factory\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_factory {
     pub get_plugin_count: unsafe extern "C" fn(factory: *const clap_plugin_factory) -> u32,
     pub get_plugin_descriptor: unsafe extern "C" fn(

--- a/src/plugin_invalidation.rs
+++ b/src/plugin_invalidation.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_invalidation_source {
     pub directory: *const c_char,
     pub filename_glob: *const c_char,
@@ -15,7 +15,7 @@ pub const CLAP_PLUGIN_INVALIDATION_FACTORY_ID: *const c_char =
     b"clap.plugin-invalidation-factory/draft0\0".as_ptr() as *const c_char;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_invalidation_factory {
     pub count: unsafe extern "C" fn(factory: *const clap_plugin_invalidation_factory) -> u32,
     pub get: unsafe extern "C" fn(

--- a/src/process.rs
+++ b/src/process.rs
@@ -10,7 +10,7 @@ pub const CLAP_PROCESS_SLEEP: clap_process_status = 4;
 pub type clap_process_status = i32;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_process {
     pub steady_time: i64,
     pub frames_count: u32,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,7 @@
 use std::ffi::c_void;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_istream {
     pub ctx: *mut c_void,
     pub read:
@@ -12,7 +12,7 @@ unsafe impl Send for clap_istream {}
 unsafe impl Sync for clap_istream {}
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_ostream {
     pub ctx: *mut c_void,
     pub write:

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,5 +1,5 @@
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct clap_version {
     pub major: u32,
     pub minor: u32,


### PR DESCRIPTION
Debugging some things was a bit awkward without these, since then you have to manually format the structs C++-style.