### PR TITLE
Use CStr for exposing CLAP string constants instead of raw pointers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "clap-sys"
 version = "0.2.0"
+rust-version = "1.59"
 authors = ["Micah Johnston <micah@glowcoil.com>", "Robbert van der Helm <mail@robbertvanderhelm.nl"]
 edition = "2021"
 description = "Rust bindings for the CLAP audio plugin API"

--- a/src/ext/audio_ports.rs
+++ b/src/ext/audio_ports.rs
@@ -1,11 +1,13 @@
 use crate::{host::*, id::*, plugin::*, string_sizes::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_AUDIO_PORTS: *const c_char = b"clap.audio-ports\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_AUDIO_PORTS: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.audio-ports\0") };
 
-pub const CLAP_PORT_MONO: *const c_char = b"mono\0".as_ptr() as *const c_char;
-pub const CLAP_PORT_STEREO: *const c_char = b"stereo\0".as_ptr() as *const c_char;
+pub const CLAP_PORT_MONO: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"mono\0") };
+pub const CLAP_PORT_STEREO: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"stereo\0") };
 
 pub const CLAP_AUDIO_PORT_IS_MAIN: u32 = 1 << 0;
 pub const CLAP_AUDIO_PORT_SUPPORTS_64BITS: u32 = 1 << 1;

--- a/src/ext/audio_ports_config.rs
+++ b/src/ext/audio_ports_config.rs
@@ -1,9 +1,10 @@
 use crate::{host::*, id::*, plugin::*, string_sizes::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_AUDIO_PORTS_CONFIG: *const c_char =
-    b"clap.audio-ports-config\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_AUDIO_PORTS_CONFIG: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.audio-ports-config\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/ambisonic.rs
+++ b/src/ext/draft/ambisonic.rs
@@ -1,10 +1,12 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_AMBISONIC: *const c_char = b"clap.ambisonic.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_AMBISONIC: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.ambisonic.draft/0\0") };
 
-pub const CLAP_PORT_AMBISONIC: *const c_char = b"ambisonic\0".as_ptr() as *const c_char;
+pub const CLAP_PORT_AMBISONIC: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"ambisonic\0") };
 
 pub const CLAP_AMBISONIC_FUMA: u32 = 0;
 pub const CLAP_AMBISONIC_ACN: u32 = 1;

--- a/src/ext/draft/check_for_update.rs
+++ b/src/ext/draft/check_for_update.rs
@@ -1,9 +1,10 @@
 use crate::{host::*, plugin::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_CHECK_FOR_UPDATE: *const c_char =
-    b"clap.check_for_update.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_CHECK_FOR_UPDATE: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.check_for_update.draft/0\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/cv.rs
+++ b/src/ext/draft/cv.rs
@@ -1,10 +1,10 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_CV: *const c_char = b"clap.cv.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_CV: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.cv.draft/0\0") };
 
-pub const CLAP_PORT_CV: *const c_char = b"cv\0".as_ptr() as *const c_char;
+pub const CLAP_PORT_CV: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"cv\0") };
 
 pub const CLAP_CV_VALUE: u32 = 0;
 pub const CLAP_CV_GATE: u32 = 1;

--- a/src/ext/draft/file_reference.rs
+++ b/src/ext/draft/file_reference.rs
@@ -1,9 +1,10 @@
 use crate::{host::*, id::*, plugin::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_FILE_REFERENCE: *const c_char =
-    b"clap.file-reference.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_FILE_REFERENCE: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.file-reference.draft/0\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/midi_mappings.rs
+++ b/src/ext/draft/midi_mappings.rs
@@ -1,9 +1,9 @@
 use crate::{host::*, id::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_MIDI_MAPPINGS: *const c_char =
-    b"clap.midi-mappings.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_MIDI_MAPPINGS: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.midi-mappings.draft/0\0") };
 
 pub const CLAP_MIDI_MAPPING_CC7: clap_midi_mapping_type = 0;
 pub const CLAP_MIDI_MAPPING_CC14: clap_midi_mapping_type = 1;

--- a/src/ext/draft/preset_load.rs
+++ b/src/ext/draft/preset_load.rs
@@ -1,9 +1,10 @@
 use crate::plugin::*;
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_PRESET_LOAD: *const c_char =
-    b"clap.preset-load.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_PRESET_LOAD: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.preset-load.draft/0\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/quick_controls.rs
+++ b/src/ext/draft/quick_controls.rs
@@ -1,9 +1,10 @@
 use crate::{host::*, id::*, plugin::*, string_sizes::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_QUICK_CONTROLS: *const c_char =
-    b"clap.quick-controls.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_QUICK_CONTROLS: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.quick-controls.draft/0\0") };
 
 pub const CLAP_QUICK_CONTROLS_COUNT: usize = 8;
 

--- a/src/ext/draft/surround.rs
+++ b/src/ext/draft/surround.rs
@@ -1,10 +1,11 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_SURROUND: *const c_char = b"clap.surround.draft/1\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_SURROUND: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.surround.draft/1\0") };
 
-pub const CLAP_PORT_SURROUND: *const c_char = b"surround\0".as_ptr() as *const c_char;
+pub const CLAP_PORT_SURROUND: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"surround\0") };
 
 pub const CLAP_SURROUND_FL: u32 = 0;
 pub const CLAP_SURROUND_FR: u32 = 1;

--- a/src/ext/draft/track_info.rs
+++ b/src/ext/draft/track_info.rs
@@ -1,9 +1,10 @@
 use crate::{color::*, host::*, id::*, plugin::*, string_sizes::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_TRACK_INFO: *const c_char =
-    b"clap.track-info.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_TRACK_INFO: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.track-info.draft/0\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/transport_control.rs
+++ b/src/ext/draft/transport_control.rs
@@ -1,9 +1,9 @@
 use crate::{fixedpoint::*, host::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_TRANSPORT_CONTROL: *const c_char =
-    b"clap.transport-control.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_TRANSPORT_CONTROL: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.transport-control.draft/0\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -1,8 +1,10 @@
 use crate::{events::*, host::*, id::*, plugin::*, string_sizes::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_TUNING: *const c_char = b"clap.tuning.draft/2\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_TUNING: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.tuning.draft/2\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/voice_info.rs
+++ b/src/ext/draft/voice_info.rs
@@ -1,9 +1,9 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_VOICE_INFO: *const c_char =
-    b"clap.voice-info.draft/0\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_VOICE_INFO: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.voice-info.draft/0\0") };
 
 pub const CLAP_VOICE_INFO_SUPPORTS_OVERLAPPING_NOTES: u64 = 1 << 0;
 

--- a/src/ext/event_registry.rs
+++ b/src/ext/event_registry.rs
@@ -1,9 +1,10 @@
 use crate::host::*;
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_EVENT_REGISTRY: *const c_char =
-    b"clap.event-registry\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_EVENT_REGISTRY: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.event-registry\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/gui.rs
+++ b/src/ext/gui.rs
@@ -1,15 +1,16 @@
 use crate::{host::*, plugin::*};
 
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr};
 use std::fmt::Debug;
 use std::os::raw::{c_char, c_ulong};
 
-pub const CLAP_EXT_GUI: *const c_char = b"clap.gui\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_GUI: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.gui\0") };
 
-pub const CLAP_WINDOW_API_WIN32: *const c_char = b"win32\0".as_ptr() as *const c_char;
-pub const CLAP_WINDOW_API_COCOA: *const c_char = b"cocoa\0".as_ptr() as *const c_char;
-pub const CLAP_WINDOW_API_X11: *const c_char = b"x11\0".as_ptr() as *const c_char;
-pub const CLAP_WINDOW_API_WAYLAND: *const c_char = b"wayland\0".as_ptr() as *const c_char;
+pub const CLAP_WINDOW_API_WIN32: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"win32\0") };
+pub const CLAP_WINDOW_API_COCOA: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"cocoa\0") };
+pub const CLAP_WINDOW_API_X11: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"x11\0") };
+pub const CLAP_WINDOW_API_WAYLAND: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"wayland\0") };
 
 pub type clap_hwnd = *mut c_void;
 pub type clap_nsview = *mut c_void;

--- a/src/ext/latency.rs
+++ b/src/ext/latency.rs
@@ -1,8 +1,9 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_LATENCY: *const c_char = b"clap.latency\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_LATENCY: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.latency\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/log.rs
+++ b/src/ext/log.rs
@@ -1,8 +1,9 @@
 use crate::host::*;
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_LOG: *const c_char = b"clap.log\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_LOG: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.log\0") };
 
 pub const CLAP_LOG_DEBUG: clap_log_severity = 0;
 pub const CLAP_LOG_INFO: clap_log_severity = 1;

--- a/src/ext/note_name.rs
+++ b/src/ext/note_name.rs
@@ -1,8 +1,10 @@
 use crate::{host::*, plugin::*, string_sizes::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_NOTE_NAME: *const c_char = b"clap.note-name\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_NOTE_NAME: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.note-name\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/note_ports.rs
+++ b/src/ext/note_ports.rs
@@ -1,8 +1,10 @@
 use crate::{host::*, id::*, plugin::*, string_sizes::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_NOTE_PORTS: *const c_char = b"clap.note-ports\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_NOTE_PORTS: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.note-ports\0") };
 
 pub const CLAP_NOTE_DIALECT_CLAP: clap_note_dialect = 1 << 0;
 pub const CLAP_NOTE_DIALECT_MIDI: clap_note_dialect = 1 << 1;

--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -1,9 +1,10 @@
 use crate::{events::*, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::c_void;
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_PARAMS: *const c_char = b"clap.params\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_PARAMS: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.params\0") };
 
 pub const CLAP_PARAM_IS_STEPPED: clap_param_info_flags = 1 << 0;
 pub const CLAP_PARAM_IS_PERIODIC: clap_param_info_flags = 1 << 1;

--- a/src/ext/posix_fd_support.rs
+++ b/src/ext/posix_fd_support.rs
@@ -1,8 +1,9 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_POSIX_FD_SUPPORT: *const c_char = b"clap.posix-fd-support\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_POSIX_FD_SUPPORT: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.posix-fd-support\0") };
 
 pub const CLAP_POSIX_FD_READ: clap_posix_fd_flags = 1 << 0;
 pub const CLAP_POSIX_FD_WRITE: clap_posix_fd_flags = 1 << 1;

--- a/src/ext/render.rs
+++ b/src/ext/render.rs
@@ -1,8 +1,8 @@
 use crate::plugin::*;
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_RENDER: *const c_char = b"clap.render\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_RENDER: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.render\0") };
 
 pub const CLAP_RENDER_REALTIME: clap_plugin_render_mode = 0;
 pub const CLAP_RENDER_OFFLINE: clap_plugin_render_mode = 1;

--- a/src/ext/state.rs
+++ b/src/ext/state.rs
@@ -1,8 +1,8 @@
 use crate::{host::*, plugin::*, stream::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_STATE: *const c_char = b"clap.state\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_STATE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.state\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/tail.rs
+++ b/src/ext/tail.rs
@@ -1,8 +1,8 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_TAIL: *const c_char = b"clap.tail\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_TAIL: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.tail\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/thread_check.rs
+++ b/src/ext/thread_check.rs
@@ -1,8 +1,9 @@
 use crate::host::*;
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_THREAD_CHECK: *const c_char = b"clap.thread-check\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_THREAD_CHECK: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.thread-check\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/thread_pool.rs
+++ b/src/ext/thread_pool.rs
@@ -1,8 +1,9 @@
 use crate::{host::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_THREAD_POOL: *const c_char = b"clap.thread-pool\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_THREAD_POOL: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.thread-pool\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/timer_support.rs
+++ b/src/ext/timer_support.rs
@@ -1,8 +1,9 @@
 use crate::{host::*, id::*, plugin::*};
 
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_EXT_TIMER_SUPPORT: *const c_char = b"clap.timer-support\0".as_ptr() as *const c_char;
+pub const CLAP_EXT_TIMER_SUPPORT: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.timer-support\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/plugin_factory.rs
+++ b/src/plugin_factory.rs
@@ -1,9 +1,10 @@
 use crate::{host::*, plugin::*};
 
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_PLUGIN_FACTORY_ID: *const c_char =
-    b"clap.plugin-factory\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FACTORY_ID: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.plugin-factory\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/plugin_features.rs
+++ b/src/plugin_features.rs
@@ -1,61 +1,86 @@
-use std::os::raw::c_char;
+use std::ffi::CStr;
 
-pub const CLAP_PLUGIN_FEATURE_INSTRUMENT: *const c_char = "instrument\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_INSTRUMENT: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"instrument\0") };
 
-pub const CLAP_PLUGIN_FEATURE_AUDIO_EFFECT: *const c_char =
-    "audio-effect\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_AUDIO_EFFECT: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"audio-effect\0") };
 
-pub const CLAP_PLUGIN_FEATURE_NOTE_EFFECT: *const c_char =
-    "note-effect\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_NOTE_EFFECT: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"note-effect\0") };
 
-pub const CLAP_PLUGIN_FEATURE_ANALYZER: *const c_char = "analyzer\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_ANALYZER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"analyzer\0") };
 
-pub const CLAP_PLUGIN_FEATURE_SYNTHESIZER: *const c_char =
-    "synthesizer\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_SAMPLER: *const c_char = "sampler\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_DRUM: *const c_char = "drum\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_DRUM_MACHINE: *const c_char =
-    "drum-machine\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_SYNTHESIZER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"synthesizer\0") };
+pub const CLAP_PLUGIN_FEATURE_SAMPLER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"sampler\0") };
+pub const CLAP_PLUGIN_FEATURE_DRUM: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"drum\0") };
+pub const CLAP_PLUGIN_FEATURE_DRUM_MACHINE: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"drum-machine\0") };
 
-pub const CLAP_PLUGIN_FEATURE_FILTER: *const c_char = "filter\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_PHASER: *const c_char = "phaser\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_EQUALIZER: *const c_char = "equalizer\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_DEESSER: *const c_char = "de-esser\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_PHASE_VOCODER: *const c_char =
-    "phase-vocoder\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_GRANULAR: *const c_char = "granular\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER: *const c_char =
-    "frequency-shifter\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_PITCH_SHIFTER: *const c_char =
-    "pitch-shifter\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_FILTER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"filter\0") };
+pub const CLAP_PLUGIN_FEATURE_PHASER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"phaser\0") };
+pub const CLAP_PLUGIN_FEATURE_EQUALIZER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"equalizer\0") };
+pub const CLAP_PLUGIN_FEATURE_DEESSER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"de-esser\0") };
+pub const CLAP_PLUGIN_FEATURE_PHASE_VOCODER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"phase-vocoder\0") };
+pub const CLAP_PLUGIN_FEATURE_GRANULAR: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"granular\0") };
+pub const CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"frequency-shifter\0") };
+pub const CLAP_PLUGIN_FEATURE_PITCH_SHIFTER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"pitch-shifter\0") };
 
-pub const CLAP_PLUGIN_FEATURE_DISTORTION: *const c_char = "distortion\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER: *const c_char =
-    "transient-shaper\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_COMPRESSOR: *const c_char = "compressor\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_LIMITER: *const c_char = "limiter\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_DISTORTION: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"distortion\0") };
+pub const CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"transient-shaper\0") };
+pub const CLAP_PLUGIN_FEATURE_COMPRESSOR: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"compressor\0") };
+pub const CLAP_PLUGIN_FEATURE_LIMITER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"limiter\0") };
 
-pub const CLAP_PLUGIN_FEATURE_FLANGER: *const c_char = "flanger\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_CHORUS: *const c_char = "chorus\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_DELAY: *const c_char = "delay\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_REVERB: *const c_char = "reverb\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_FLANGER: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"flanger\0") };
+pub const CLAP_PLUGIN_FEATURE_CHORUS: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"chorus\0") };
+pub const CLAP_PLUGIN_FEATURE_DELAY: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"delay\0") };
+pub const CLAP_PLUGIN_FEATURE_REVERB: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"reverb\0") };
 
-pub const CLAP_PLUGIN_FEATURE_TREMOLO: *const c_char = "tremolo\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_GLITCH: *const c_char = "glitch\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_TREMOLO: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"tremolo\0") };
+pub const CLAP_PLUGIN_FEATURE_GLITCH: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"glitch\0") };
 
-pub const CLAP_PLUGIN_FEATURE_UTILITY: *const c_char = "utility\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_PITCH_CORRECTION: *const c_char =
-    "pitch-correction\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_RESTORATION: *const c_char =
-    "restoration\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_UTILITY: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"utility\0") };
+pub const CLAP_PLUGIN_FEATURE_PITCH_CORRECTION: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"pitch-correction\0") };
+pub const CLAP_PLUGIN_FEATURE_RESTORATION: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"restoration\0") };
 
-pub const CLAP_PLUGIN_FEATURE_MULTI_EFFECTS: *const c_char =
-    "multi-effects\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_MULTI_EFFECTS: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"multi-effects\0") };
 
-pub const CLAP_PLUGIN_FEATURE_MIXING: *const c_char = "mixing\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_MASTERING: *const c_char = "mastering\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_MIXING: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"mixing\0") };
+pub const CLAP_PLUGIN_FEATURE_MASTERING: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"mastering\0") };
 
-pub const CLAP_PLUGIN_FEATURE_MONO: *const c_char = "mono\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_STEREO: *const c_char = "stereo\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_SURROUND: *const c_char = "surround\0".as_ptr() as *const c_char;
-pub const CLAP_PLUGIN_FEATURE_AMBISONIC: *const c_char = "ambisonic\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_FEATURE_MONO: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"mono\0") };
+pub const CLAP_PLUGIN_FEATURE_STEREO: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"stereo\0") };
+pub const CLAP_PLUGIN_FEATURE_SURROUND: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"surround\0") };
+pub const CLAP_PLUGIN_FEATURE_AMBISONIC: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"ambisonic\0") };

--- a/src/plugin_invalidation.rs
+++ b/src/plugin_invalidation.rs
@@ -1,3 +1,4 @@
+use std::ffi::CStr;
 use std::os::raw::c_char;
 
 #[repr(C)]
@@ -11,8 +12,8 @@ pub struct clap_plugin_invalidation_source {
 unsafe impl Send for clap_plugin_invalidation_source {}
 unsafe impl Sync for clap_plugin_invalidation_source {}
 
-pub const CLAP_PLUGIN_INVALIDATION_FACTORY_ID: *const c_char =
-    b"clap.plugin-invalidation-factory/draft0\0".as_ptr() as *const c_char;
+pub const CLAP_PLUGIN_INVALIDATION_FACTORY_ID: &CStr =
+    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.plugin-invalidation-factory/draft0\0") };
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Since `CStr::from_bytes_with_nul_unchecked()` is const only as of Rust 1.59, I also took the opportunity to add that requirement in Cargo.toml. :slightly_smiling_face: 