### PR TITLE
Update for CLAP 1.0.3

### DIFF
--- a/src/ext/gui.rs
+++ b/src/ext/gui.rs
@@ -44,7 +44,7 @@ unsafe impl Sync for clap_window_handle {}
 pub struct clap_gui_resize_hints {
     pub can_resize_horizontally: bool,
     pub can_resize_vertically: bool,
-    pub preseve_aspect_ratio: bool,
+    pub preserve_aspect_ratio: bool,
     pub aspect_ratio_width: u32,
     pub aspect_ratio_height: u32,
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,7 +8,7 @@ pub struct clap_version {
 
 pub const CLAP_VERSION_MAJOR: u32 = 1;
 pub const CLAP_VERSION_MINOR: u32 = 0;
-pub const CLAP_VERSION_REVISION: u32 = 1;
+pub const CLAP_VERSION_REVISION: u32 = 3;
 
 pub const CLAP_VERSION: clap_version = clap_version {
     major: CLAP_VERSION_MAJOR,


### PR DESCRIPTION
Based on https://github.com/free-audio/clap/compare/1.0.1...1.0.3. Other than a typo fix in a struct field nothing's really changed since CLAP 1.0.1, but it's probably a good idea to stay on top of this since otherwise the diffs will just keep growing and growing.