### PR TITLE
Change every function pointer type to an Option

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -7,7 +7,7 @@ use std::os::raw::c_char;
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_entry {
     pub clap_version: clap_version,
-    pub init: unsafe extern "C" fn(plugin_path: *const c_char) -> bool,
-    pub deinit: unsafe extern "C" fn(),
-    pub get_factory: unsafe extern "C" fn(factory_id: *const c_char) -> *const c_void,
+    pub init: Option<unsafe extern "C" fn(plugin_path: *const c_char) -> bool>,
+    pub deinit: Option<unsafe extern "C" fn()>,
+    pub get_factory: Option<unsafe extern "C" fn(factory_id: *const c_char) -> *const c_void>,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -169,11 +169,13 @@ pub struct clap_event_midi2 {
 #[derive(Debug, Copy, Clone)]
 pub struct clap_input_events {
     pub ctx: *mut c_void,
-    pub size: unsafe extern "C" fn(list: *const clap_input_events) -> u32,
-    pub get: unsafe extern "C" fn(
-        list: *const clap_input_events,
-        index: u32,
-    ) -> *const clap_event_header,
+    pub size: Option<unsafe extern "C" fn(list: *const clap_input_events) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            list: *const clap_input_events,
+            index: u32,
+        ) -> *const clap_event_header,
+    >,
 }
 
 unsafe impl Send for clap_input_events {}
@@ -183,10 +185,12 @@ unsafe impl Sync for clap_input_events {}
 #[derive(Debug, Copy, Clone)]
 pub struct clap_output_events {
     pub ctx: *mut c_void,
-    pub try_push: unsafe extern "C" fn(
-        list: *const clap_output_events,
-        event: *const clap_event_header,
-    ) -> bool,
+    pub try_push: Option<
+        unsafe extern "C" fn(
+            list: *const clap_output_events,
+            event: *const clap_event_header,
+        ) -> bool,
+    >,
 }
 
 unsafe impl Send for clap_output_events {}

--- a/src/ext/audio_ports.rs
+++ b/src/ext/audio_ports.rs
@@ -31,13 +31,15 @@ unsafe impl Sync for clap_audio_port_info {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_audio_ports {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin, is_input: bool) -> u32,
-    pub get: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        index: u32,
-        is_input: bool,
-        info: *mut clap_audio_port_info,
-    ) -> bool,
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin, is_input: bool) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            index: u32,
+            is_input: bool,
+            info: *mut clap_audio_port_info,
+        ) -> bool,
+    >,
 }
 
 pub const CLAP_AUDIO_PORTS_RESCAN_NAMES: u32 = 1 << 0;
@@ -50,6 +52,7 @@ pub const CLAP_AUDIO_PORTS_RESCAN_LIST: u32 = 1 << 5;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_audio_ports {
-    pub is_rescan_flag_supported: unsafe extern "C" fn(host: *const clap_host, flag: u32) -> bool,
-    pub rescan: unsafe extern "C" fn(host: *const clap_host, flags: u32),
+    pub is_rescan_flag_supported:
+        Option<unsafe extern "C" fn(host: *const clap_host, flag: u32) -> bool>,
+    pub rescan: Option<unsafe extern "C" fn(host: *const clap_host, flags: u32)>,
 }

--- a/src/ext/audio_ports_config.rs
+++ b/src/ext/audio_ports_config.rs
@@ -30,17 +30,20 @@ unsafe impl Sync for clap_audio_ports_config {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_audio_ports_config {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
-    pub get: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        index: u32,
-        config: *mut clap_audio_ports_config,
-    ) -> bool,
-    pub select: unsafe extern "C" fn(plugin: *const clap_plugin, config_id: clap_id) -> bool,
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            index: u32,
+            config: *mut clap_audio_ports_config,
+        ) -> bool,
+    >,
+    pub select:
+        Option<unsafe extern "C" fn(plugin: *const clap_plugin, config_id: clap_id) -> bool>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_audio_ports_config {
-    pub rescan: unsafe extern "C" fn(host: *const clap_host),
+    pub rescan: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/draft/ambisonic.rs
+++ b/src/ext/draft/ambisonic.rs
@@ -27,16 +27,18 @@ pub struct clap_ambisonic_info {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_ambisonic {
-    pub get_info: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        is_input: bool,
-        port_index: u32,
-        info: *mut clap_ambisonic_info,
-    ) -> bool,
+    pub get_info: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            is_input: bool,
+            port_index: u32,
+            info: *mut clap_ambisonic_info,
+        ) -> bool,
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_ambisonic {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/draft/check_for_update.rs
+++ b/src/ext/draft/check_for_update.rs
@@ -21,14 +21,16 @@ unsafe impl Sync for clap_check_for_update_info {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_check_for_update {
-    pub check: unsafe extern "C" fn(plugin: *const clap_plugin, include_preview: bool),
+    pub check: Option<unsafe extern "C" fn(plugin: *const clap_plugin, include_preview: bool)>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_check_for_update {
-    pub on_new_version: unsafe extern "C" fn(
-        host: *const clap_host,
-        update_info: *const clap_check_for_update_info,
-    ),
+    pub on_new_version: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            update_info: *const clap_check_for_update_info,
+        ),
+    >,
 }

--- a/src/ext/draft/cv.rs
+++ b/src/ext/draft/cv.rs
@@ -13,17 +13,19 @@ pub const CLAP_CV_PITCH: u32 = 2;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_cv {
-    pub get_channel_type: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        is_input: bool,
-        port_index: u32,
-        channel_index: u32,
-        channel_type: *mut u32,
-    ) -> bool,
+    pub get_channel_type: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            is_input: bool,
+            port_index: u32,
+            channel_index: u32,
+            channel_type: *mut u32,
+        ) -> bool,
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_cv {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/draft/file_reference.rs
+++ b/src/ext/draft/file_reference.rs
@@ -22,33 +22,41 @@ unsafe impl Sync for clap_file_reference {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_file_reference {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
-    pub get: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        index: u32,
-        file_reference: *mut clap_file_reference,
-    ) -> bool,
-    pub get_blake3_digest: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        resource_id: clap_id,
-        digest: *mut u8,
-    ) -> bool,
-    pub get_file_size: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        resource_id: clap_id,
-        size: *mut u64,
-    ) -> bool,
-    pub update_path: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        resource_id: clap_id,
-        path: *const c_char,
-    ) -> bool,
-    pub save_resources: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            index: u32,
+            file_reference: *mut clap_file_reference,
+        ) -> bool,
+    >,
+    pub get_blake3_digest: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            resource_id: clap_id,
+            digest: *mut u8,
+        ) -> bool,
+    >,
+    pub get_file_size: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            resource_id: clap_id,
+            size: *mut u64,
+        ) -> bool,
+    >,
+    pub update_path: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            resource_id: clap_id,
+            path: *const c_char,
+        ) -> bool,
+    >,
+    pub save_resources: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> bool>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_file_reference {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
-    pub set_dirty: unsafe extern "C" fn(host: *const clap_host, resource_id: clap_id),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub set_dirty: Option<unsafe extern "C" fn(host: *const clap_host, resource_id: clap_id)>,
 }

--- a/src/ext/draft/midi_mappings.rs
+++ b/src/ext/draft/midi_mappings.rs
@@ -25,16 +25,18 @@ pub struct clap_midi_mapping {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_midi_mappings {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
-    pub get: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        index: u32,
-        mapping: *mut clap_midi_mapping,
-    ) -> bool,
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            index: u32,
+            mapping: *mut clap_midi_mapping,
+        ) -> bool,
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_midi_mappings {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/draft/preset_load.rs
+++ b/src/ext/draft/preset_load.rs
@@ -9,5 +9,6 @@ pub const CLAP_EXT_PRESET_LOAD: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_preset_load {
-    pub from_file: unsafe extern "C" fn(plugin: *const clap_plugin, path: *const c_char) -> bool,
+    pub from_file:
+        Option<unsafe extern "C" fn(plugin: *const clap_plugin, path: *const c_char) -> bool>,
 }

--- a/src/ext/draft/quick_controls.rs
+++ b/src/ext/draft/quick_controls.rs
@@ -22,17 +22,19 @@ unsafe impl Sync for clap_quick_controls_page {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_quick_controls {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
-    pub get: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        page_index: u32,
-        page: *mut clap_quick_controls_page,
-    ) -> bool,
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            page_index: u32,
+            page: *mut clap_quick_controls_page,
+        ) -> bool,
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_quick_controls {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
-    pub suggest_page: unsafe extern "C" fn(host: *const clap_host, page_id: clap_id),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub suggest_page: Option<unsafe extern "C" fn(host: *const clap_host, page_id: clap_id)>,
 }

--- a/src/ext/draft/surround.rs
+++ b/src/ext/draft/surround.rs
@@ -29,24 +29,28 @@ pub const CLAP_SURROUND_TBR: u32 = 17;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_surround {
-    pub get_channel_map: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        is_input: bool,
-        port_index: u32,
-        channel_map: *mut u8,
-        channel_map_capacity: u32,
-    ) -> u32,
-    pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
+    pub get_channel_map: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            is_input: bool,
+            port_index: u32,
+            channel_map: *mut u8,
+            channel_map_capacity: u32,
+        ) -> u32,
+    >,
+    pub changed: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_surround {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
-    pub get_preferred_channel_map: unsafe extern "C" fn(
-        plugin: *const clap_host,
-        channel_map: *mut u8,
-        channel_map_capacity: u32,
-        channel_count: *mut u32,
-    ),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub get_preferred_channel_map: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_host,
+            channel_map: *mut u8,
+            channel_map_capacity: u32,
+            channel_count: *mut u32,
+        ),
+    >,
 }

--- a/src/ext/draft/track_info.rs
+++ b/src/ext/draft/track_info.rs
@@ -25,11 +25,12 @@ unsafe impl Sync for clap_track_info {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_track_info {
-    pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
+    pub changed: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_track_info {
-    pub get: unsafe extern "C" fn(host: *const clap_host, info: *mut clap_track_info) -> bool,
+    pub get:
+        Option<unsafe extern "C" fn(host: *const clap_host, info: *mut clap_track_info) -> bool>,
 }

--- a/src/ext/draft/transport_control.rs
+++ b/src/ext/draft/transport_control.rs
@@ -8,16 +8,17 @@ pub const CLAP_EXT_TRANSPORT_CONTROL: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_transport_control {
-    pub request_start: unsafe extern "C" fn(host: *const clap_host),
-    pub request_stop: unsafe extern "C" fn(host: *const clap_host),
-    pub request_continue: unsafe extern "C" fn(host: *const clap_host),
-    pub request_pause: unsafe extern "C" fn(host: *const clap_host),
-    pub request_toggle_play: unsafe extern "C" fn(host: *const clap_host),
-    pub request_jump: unsafe extern "C" fn(host: *const clap_host, position: clap_beattime),
-    pub request_loop_region:
+    pub request_start: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_stop: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_continue: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_pause: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_toggle_play: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_jump: Option<unsafe extern "C" fn(host: *const clap_host, position: clap_beattime)>,
+    pub request_loop_region: Option<
         unsafe extern "C" fn(host: *const clap_host, start: clap_beattime, duration: clap_beattime),
-    pub request_toggle_loop: unsafe extern "C" fn(host: *const clap_host),
-    pub request_enable_loop: unsafe extern "C" fn(host: *const clap_host, is_enabled: bool),
-    pub request_record: unsafe extern "C" fn(host: *const clap_host, is_recording: bool),
-    pub request_toggle_record: unsafe extern "C" fn(host: *const clap_host),
+    >,
+    pub request_toggle_loop: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_enable_loop: Option<unsafe extern "C" fn(host: *const clap_host, is_enabled: bool)>,
+    pub request_record: Option<unsafe extern "C" fn(host: *const clap_host, is_recording: bool)>,
+    pub request_toggle_record: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -29,29 +29,35 @@ unsafe impl Sync for clap_tuning_info {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_tuning_t {
-    pub changed: unsafe extern "C" fn(plugin: *const clap_plugin),
+    pub changed: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_tuning {
-    pub get_relative: unsafe extern "C" fn(
-        host: *const clap_host,
-        tuning_id: clap_id,
-        channel: i32,
-        key: i32,
-        sample_offset: u32,
-    ) -> f64,
-    pub should_play: unsafe extern "C" fn(
-        host: *const clap_host,
-        tuning_id: clap_id,
-        channel: i32,
-        key: i32,
-    ) -> bool,
-    pub get_tuning_count: unsafe extern "C" fn(host: *const clap_host) -> u32,
-    pub get_info: unsafe extern "C" fn(
-        host: *const clap_host,
-        tuning_index: u32,
-        info: *mut clap_tuning_info,
-    ) -> bool,
+    pub get_relative: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            tuning_id: clap_id,
+            channel: i32,
+            key: i32,
+            sample_offset: u32,
+        ) -> f64,
+    >,
+    pub should_play: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            tuning_id: clap_id,
+            channel: i32,
+            key: i32,
+        ) -> bool,
+    >,
+    pub get_tuning_count: Option<unsafe extern "C" fn(host: *const clap_host) -> u32>,
+    pub get_info: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            tuning_index: u32,
+            info: *mut clap_tuning_info,
+        ) -> bool,
+    >,
 }

--- a/src/ext/draft/voice_info.rs
+++ b/src/ext/draft/voice_info.rs
@@ -18,11 +18,13 @@ pub struct clap_voice_info {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_voice_info {
-    pub get: unsafe extern "C" fn(plugin: *const clap_plugin, info: *mut clap_voice_info) -> bool,
+    pub get: Option<
+        unsafe extern "C" fn(plugin: *const clap_plugin, info: *mut clap_voice_info) -> bool,
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_voice_info {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/event_registry.rs
+++ b/src/ext/event_registry.rs
@@ -9,9 +9,11 @@ pub const CLAP_EXT_EVENT_REGISTRY: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_event_registry {
-    pub query: unsafe extern "C" fn(
-        host: *const clap_host,
-        space_name: *const c_char,
-        space_id: *mut u16,
-    ) -> bool,
+    pub query: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            space_name: *const c_char,
+            space_id: *mut u16,
+        ) -> bool,
+    >,
 }

--- a/src/ext/gui.rs
+++ b/src/ext/gui.rs
@@ -52,49 +52,62 @@ pub struct clap_gui_resize_hints {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_gui {
-    pub is_api_supported: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        api: *const c_char,
-        is_floating: bool,
-    ) -> bool,
-    pub get_preferred_api: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        api: *mut *const c_char,
-        is_floating: *mut bool,
-    ) -> bool,
-    pub create: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        api: *const c_char,
-        is_floating: bool,
-    ) -> bool,
-    pub destroy: unsafe extern "C" fn(plugin: *const clap_plugin),
-    pub set_scale: unsafe extern "C" fn(plugin: *const clap_plugin, scale: f64) -> bool,
-    pub get_size:
+    pub is_api_supported: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            api: *const c_char,
+            is_floating: bool,
+        ) -> bool,
+    >,
+    pub get_preferred_api: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            api: *mut *const c_char,
+            is_floating: *mut bool,
+        ) -> bool,
+    >,
+    pub create: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            api: *const c_char,
+            is_floating: bool,
+        ) -> bool,
+    >,
+    pub destroy: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
+    pub set_scale: Option<unsafe extern "C" fn(plugin: *const clap_plugin, scale: f64) -> bool>,
+    pub get_size: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, width: *mut u32, height: *mut u32) -> bool,
-    pub can_resize: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
-    pub get_resize_hints:
+    >,
+    pub can_resize: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> bool>,
+    pub get_resize_hints: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, hints: *mut clap_gui_resize_hints) -> bool,
-    pub adjust_size:
+    >,
+    pub adjust_size: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, width: *mut u32, height: *mut u32) -> bool,
-    pub set_size: unsafe extern "C" fn(plugin: *const clap_plugin, width: u32, height: u32) -> bool,
-    pub set_parent:
+    >,
+    pub set_size:
+        Option<unsafe extern "C" fn(plugin: *const clap_plugin, width: u32, height: u32) -> bool>,
+    pub set_parent: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, window: *const clap_window) -> bool,
-    pub set_transient:
+    >,
+    pub set_transient: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, window: *const clap_window) -> bool,
-    pub suggest_title: unsafe extern "C" fn(plugin: *const clap_plugin, title: *const c_char),
-    pub show: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
-    pub hide: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
+    >,
+    pub suggest_title:
+        Option<unsafe extern "C" fn(plugin: *const clap_plugin, title: *const c_char)>,
+    pub show: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> bool>,
+    pub hide: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> bool>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_gui {
-    pub resize_hints_changed: unsafe extern "C" fn(host: *const clap_host),
+    pub resize_hints_changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
     pub request_resize:
-        unsafe extern "C" fn(host: *const clap_host, width: u32, height: u32) -> bool,
-    pub request_show: unsafe extern "C" fn(host: *const clap_host) -> bool,
-    pub request_hide: unsafe extern "C" fn(host: *const clap_host) -> bool,
-    pub closed: unsafe extern "C" fn(host: *const clap_host, was_destroyed: bool),
+        Option<unsafe extern "C" fn(host: *const clap_host, width: u32, height: u32) -> bool>,
+    pub request_show: Option<unsafe extern "C" fn(host: *const clap_host) -> bool>,
+    pub request_hide: Option<unsafe extern "C" fn(host: *const clap_host) -> bool>,
+    pub closed: Option<unsafe extern "C" fn(host: *const clap_host, was_destroyed: bool)>,
 }
 
 impl Debug for clap_window_handle {

--- a/src/ext/latency.rs
+++ b/src/ext/latency.rs
@@ -8,11 +8,11 @@ pub const CLAP_EXT_LATENCY: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_latency {
-    pub get: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
+    pub get: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_latency {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/log.rs
+++ b/src/ext/log.rs
@@ -18,9 +18,11 @@ pub type clap_log_severity = i32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_log {
-    pub log: unsafe extern "C" fn(
-        host: *const clap_host,
-        severity: clap_log_severity,
-        msg: *const c_char,
-    ),
+    pub log: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            severity: clap_log_severity,
+            msg: *const c_char,
+        ),
+    >,
 }

--- a/src/ext/note_name.rs
+++ b/src/ext/note_name.rs
@@ -18,16 +18,18 @@ pub struct clap_note_name {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_note_name {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
-    pub get: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        index: u32,
-        note_name: *mut clap_note_name,
-    ) -> bool,
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            index: u32,
+            note_name: *mut clap_note_name,
+        ) -> bool,
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_note_name {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/note_ports.rs
+++ b/src/ext/note_ports.rs
@@ -25,13 +25,15 @@ pub struct clap_note_port_info {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_note_ports {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin, is_input: bool) -> u32,
-    pub get: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        index: u32,
-        is_input: bool,
-        info: *mut clap_note_port_info,
-    ) -> bool,
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin, is_input: bool) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            index: u32,
+            is_input: bool,
+            info: *mut clap_note_port_info,
+        ) -> bool,
+    >,
 }
 
 pub const CLAP_NOTE_PORTS_RESCAN_ALL: u32 = 1 << 0;
@@ -40,6 +42,7 @@ pub const CLAP_NOTE_PORTS_RESCAN_NAMES: u32 = 1 << 1;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_note_ports {
-    pub supported_dialects: unsafe extern "C" fn(host: *const clap_host) -> clap_note_dialect,
-    pub rescan: unsafe extern "C" fn(host: *const clap_host, flags: u32),
+    pub supported_dialects:
+        Option<unsafe extern "C" fn(host: *const clap_host) -> clap_note_dialect>,
+    pub rescan: Option<unsafe extern "C" fn(host: *const clap_host, flags: u32)>,
 }

--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -44,35 +44,45 @@ unsafe impl Sync for clap_param_info {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_params {
-    pub count: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
-    pub get_info: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        param_index: u32,
-        param_info: *mut clap_param_info,
-    ) -> bool,
-    pub get_value: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        param_id: clap_id,
-        value: *mut f64,
-    ) -> bool,
-    pub value_to_text: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        param_id: clap_id,
-        value: f64,
-        display: *mut c_char,
-        size: u32,
-    ) -> bool,
-    pub text_to_value: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        param_id: clap_id,
-        display: *const c_char,
-        value: *mut f64,
-    ) -> bool,
-    pub flush: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        in_: *const clap_input_events,
-        out: *const clap_output_events,
-    ),
+    pub count: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
+    pub get_info: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            param_index: u32,
+            param_info: *mut clap_param_info,
+        ) -> bool,
+    >,
+    pub get_value: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            param_id: clap_id,
+            value: *mut f64,
+        ) -> bool,
+    >,
+    pub value_to_text: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            param_id: clap_id,
+            value: f64,
+            display: *mut c_char,
+            size: u32,
+        ) -> bool,
+    >,
+    pub text_to_value: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            param_id: clap_id,
+            display: *const c_char,
+            value: *mut f64,
+        ) -> bool,
+    >,
+    pub flush: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            in_: *const clap_input_events,
+            out: *const clap_output_events,
+        ),
+    >,
 }
 
 pub const CLAP_PARAM_RESCAN_VALUES: clap_param_rescan_flags = 1 << 0;
@@ -91,11 +101,14 @@ pub type clap_param_clear_flags = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_params {
-    pub rescan: unsafe extern "C" fn(host: *const clap_host, flags: clap_param_rescan_flags),
-    pub clear: unsafe extern "C" fn(
-        host: *const clap_host,
-        param_id: clap_id,
-        flags: clap_param_clear_flags,
-    ),
-    pub request_flush: unsafe extern "C" fn(host: *const clap_host),
+    pub rescan:
+        Option<unsafe extern "C" fn(host: *const clap_host, flags: clap_param_rescan_flags)>,
+    pub clear: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            param_id: clap_id,
+            flags: clap_param_clear_flags,
+        ),
+    >,
+    pub request_flush: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/posix_fd_support.rs
+++ b/src/ext/posix_fd_support.rs
@@ -14,16 +14,19 @@ pub type clap_posix_fd_flags = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_posix_fd_support {
-    pub on_fd:
+    pub on_fd: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, fd: i32, flags: clap_posix_fd_flags),
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_posix_fd_support {
-    pub register_fd:
+    pub register_fd: Option<
         unsafe extern "C" fn(host: *const clap_host, fd: i32, flags: clap_posix_fd_flags) -> bool,
-    pub modify_fd:
+    >,
+    pub modify_fd: Option<
         unsafe extern "C" fn(host: *const clap_host, fd: i32, flags: clap_posix_fd_flags) -> bool,
-    pub unregister_fd: unsafe extern "C" fn(host: *const clap_host, fd: i32) -> bool,
+    >,
+    pub unregister_fd: Option<unsafe extern "C" fn(host: *const clap_host, fd: i32) -> bool>,
 }

--- a/src/ext/render.rs
+++ b/src/ext/render.rs
@@ -12,7 +12,9 @@ pub type clap_plugin_render_mode = i32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_render {
-    pub has_hard_realtime_requirement: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
-    pub set:
+    pub has_hard_realtime_requirement:
+        Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> bool>,
+    pub set: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, mode: clap_plugin_render_mode) -> bool,
+    >,
 }

--- a/src/ext/state.rs
+++ b/src/ext/state.rs
@@ -7,12 +7,16 @@ pub const CLAP_EXT_STATE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_state {
-    pub save: unsafe extern "C" fn(plugin: *const clap_plugin, stream: *const clap_ostream) -> bool,
-    pub load: unsafe extern "C" fn(plugin: *const clap_plugin, stream: *const clap_istream) -> bool,
+    pub save: Option<
+        unsafe extern "C" fn(plugin: *const clap_plugin, stream: *const clap_ostream) -> bool,
+    >,
+    pub load: Option<
+        unsafe extern "C" fn(plugin: *const clap_plugin, stream: *const clap_istream) -> bool,
+    >,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_state {
-    pub mark_dirty: unsafe extern "C" fn(host: *const clap_host),
+    pub mark_dirty: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/tail.rs
+++ b/src/ext/tail.rs
@@ -7,11 +7,11 @@ pub const CLAP_EXT_TAIL: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_tail {
-    pub get: unsafe extern "C" fn(plugin: *const clap_plugin) -> u32,
+    pub get: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> u32>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_tail {
-    pub changed: unsafe extern "C" fn(host: *const clap_host),
+    pub changed: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }

--- a/src/ext/thread_check.rs
+++ b/src/ext/thread_check.rs
@@ -8,6 +8,6 @@ pub const CLAP_EXT_THREAD_CHECK: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_thread_check {
-    pub is_main_thread: unsafe extern "C" fn(host: *const clap_host) -> bool,
-    pub is_audio_thread: unsafe extern "C" fn(host: *const clap_host) -> bool,
+    pub is_main_thread: Option<unsafe extern "C" fn(host: *const clap_host) -> bool>,
+    pub is_audio_thread: Option<unsafe extern "C" fn(host: *const clap_host) -> bool>,
 }

--- a/src/ext/thread_pool.rs
+++ b/src/ext/thread_pool.rs
@@ -8,11 +8,11 @@ pub const CLAP_EXT_THREAD_POOL: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_thread_pool {
-    pub exec: unsafe extern "C" fn(plugin: *const clap_plugin, task_index: u32),
+    pub exec: Option<unsafe extern "C" fn(plugin: *const clap_plugin, task_index: u32)>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_thread_pool {
-    pub request_exec: unsafe extern "C" fn(host: *const clap_host, num_tasks: u32) -> bool,
+    pub request_exec: Option<unsafe extern "C" fn(host: *const clap_host, num_tasks: u32) -> bool>,
 }

--- a/src/ext/timer_support.rs
+++ b/src/ext/timer_support.rs
@@ -8,16 +8,19 @@ pub const CLAP_EXT_TIMER_SUPPORT: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_timer_support {
-    pub on_timer: unsafe extern "C" fn(plugin: *const clap_plugin, timer_id: clap_id),
+    pub on_timer: Option<unsafe extern "C" fn(plugin: *const clap_plugin, timer_id: clap_id)>,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_host_timer_support {
-    pub register_timer: unsafe extern "C" fn(
-        host: *const clap_host,
-        period_ms: u32,
-        timer_id: *mut clap_id,
-    ) -> bool,
-    pub unregister_timer: unsafe extern "C" fn(host: *const clap_host, timer_id: clap_id) -> bool,
+    pub register_timer: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            period_ms: u32,
+            timer_id: *mut clap_id,
+        ) -> bool,
+    >,
+    pub unregister_timer:
+        Option<unsafe extern "C" fn(host: *const clap_host, timer_id: clap_id) -> bool>,
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -12,11 +12,12 @@ pub struct clap_host {
     pub vendor: *const c_char,
     pub url: *const c_char,
     pub version: *const c_char,
-    pub get_extension:
+    pub get_extension: Option<
         unsafe extern "C" fn(host: *const clap_host, extension_id: *const c_char) -> *const c_void,
-    pub request_restart: unsafe extern "C" fn(host: *const clap_host),
-    pub request_process: unsafe extern "C" fn(host: *const clap_host),
-    pub request_callback: unsafe extern "C" fn(host: *const clap_host),
+    >,
+    pub request_restart: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_process: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub request_callback: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }
 
 unsafe impl Send for clap_host {}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -26,25 +26,30 @@ unsafe impl Sync for clap_plugin_descriptor {}
 pub struct clap_plugin {
     pub desc: *const clap_plugin_descriptor,
     pub plugin_data: *mut c_void,
-    pub init: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
-    pub destroy: unsafe extern "C" fn(plugin: *const clap_plugin),
-    pub activate: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        sample_rate: f64,
-        min_frames_count: u32,
-        max_frames_count: u32,
-    ) -> bool,
-    pub deactivate: unsafe extern "C" fn(plugin: *const clap_plugin),
-    pub start_processing: unsafe extern "C" fn(plugin: *const clap_plugin) -> bool,
-    pub stop_processing: unsafe extern "C" fn(plugin: *const clap_plugin),
-    pub reset: unsafe extern "C" fn(plugin: *const clap_plugin),
-    pub process: unsafe extern "C" fn(
-        plugin: *const clap_plugin,
-        process: *const clap_process,
-    ) -> clap_process_status,
-    pub get_extension:
+    pub init: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> bool>,
+    pub destroy: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
+    pub activate: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            sample_rate: f64,
+            min_frames_count: u32,
+            max_frames_count: u32,
+        ) -> bool,
+    >,
+    pub deactivate: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
+    pub start_processing: Option<unsafe extern "C" fn(plugin: *const clap_plugin) -> bool>,
+    pub stop_processing: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
+    pub reset: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
+    pub process: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            process: *const clap_process,
+        ) -> clap_process_status,
+    >,
+    pub get_extension: Option<
         unsafe extern "C" fn(plugin: *const clap_plugin, id: *const c_char) -> *const c_void,
-    pub on_main_thread: unsafe extern "C" fn(plugin: *const clap_plugin),
+    >,
+    pub on_main_thread: Option<unsafe extern "C" fn(plugin: *const clap_plugin)>,
 }
 
 unsafe impl Send for clap_plugin {}

--- a/src/plugin_factory.rs
+++ b/src/plugin_factory.rs
@@ -9,14 +9,18 @@ pub const CLAP_PLUGIN_FACTORY_ID: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_factory {
-    pub get_plugin_count: unsafe extern "C" fn(factory: *const clap_plugin_factory) -> u32,
-    pub get_plugin_descriptor: unsafe extern "C" fn(
-        factory: *const clap_plugin_factory,
-        index: u32,
-    ) -> *const clap_plugin_descriptor,
-    pub create_plugin: unsafe extern "C" fn(
-        factory: *const clap_plugin_factory,
-        host: *const clap_host,
-        plugin_id: *const c_char,
-    ) -> *const clap_plugin,
+    pub get_plugin_count: Option<unsafe extern "C" fn(factory: *const clap_plugin_factory) -> u32>,
+    pub get_plugin_descriptor: Option<
+        unsafe extern "C" fn(
+            factory: *const clap_plugin_factory,
+            index: u32,
+        ) -> *const clap_plugin_descriptor,
+    >,
+    pub create_plugin: Option<
+        unsafe extern "C" fn(
+            factory: *const clap_plugin_factory,
+            host: *const clap_host,
+            plugin_id: *const c_char,
+        ) -> *const clap_plugin,
+    >,
 }

--- a/src/plugin_invalidation.rs
+++ b/src/plugin_invalidation.rs
@@ -18,10 +18,14 @@ pub const CLAP_PLUGIN_INVALIDATION_FACTORY_ID: &CStr =
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct clap_plugin_invalidation_factory {
-    pub count: unsafe extern "C" fn(factory: *const clap_plugin_invalidation_factory) -> u32,
-    pub get: unsafe extern "C" fn(
-        factory: *const clap_plugin_invalidation_factory,
-        index: u32,
-    ) -> *const clap_plugin_invalidation_source,
-    pub refresh: unsafe extern "C" fn(factory: *const clap_plugin_invalidation_factory) -> bool,
+    pub count:
+        Option<unsafe extern "C" fn(factory: *const clap_plugin_invalidation_factory) -> u32>,
+    pub get: Option<
+        unsafe extern "C" fn(
+            factory: *const clap_plugin_invalidation_factory,
+            index: u32,
+        ) -> *const clap_plugin_invalidation_source,
+    >,
+    pub refresh:
+        Option<unsafe extern "C" fn(factory: *const clap_plugin_invalidation_factory) -> bool>,
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,8 +4,9 @@ use std::ffi::c_void;
 #[derive(Debug, Copy, Clone)]
 pub struct clap_istream {
     pub ctx: *mut c_void,
-    pub read:
+    pub read: Option<
         unsafe extern "C" fn(stream: *const clap_istream, buffer: *mut c_void, size: u64) -> i64,
+    >,
 }
 
 unsafe impl Send for clap_istream {}
@@ -15,8 +16,9 @@ unsafe impl Sync for clap_istream {}
 #[derive(Debug, Copy, Clone)]
 pub struct clap_ostream {
     pub ctx: *mut c_void,
-    pub write:
+    pub write: Option<
         unsafe extern "C" fn(stream: *const clap_ostream, buffer: *const c_void, size: u64) -> i64,
+    >,
 }
 
 unsafe impl Send for clap_ostream {}


### PR DESCRIPTION
Rust's function pointer types do not permit null values, so constructing one from null (with transmute, or by being passed a null pointer over FFI) results in undefined behavior. Nullable function pointer types should be represented as an `Option<fn(...) -> ...>`, which has the same ABI as `fn(...) -> ...` but allows null values.

For well-behaved CLAP hosts and plugins, this should not be an issue, since none of the function pointers found in the API are ever permitted to be null. However, hosts and plugins are not always well behaved, and it's desirable to be able to explicitly handle null function pointers without invoking UB, at least in the setting of a plugin validator or similar. So, this change wraps every function pointer type in an `Option`.