### PR TITLE
Update for CLAP 1.1.2

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -8,7 +8,7 @@ pub struct clap_version {
 
 pub const CLAP_VERSION_MAJOR: u32 = 1;
 pub const CLAP_VERSION_MINOR: u32 = 1;
-pub const CLAP_VERSION_REVISION: u32 = 1;
+pub const CLAP_VERSION_REVISION: u32 = 2;
 
 pub const CLAP_VERSION: clap_version = clap_version {
     major: CLAP_VERSION_MAJOR,


### PR DESCRIPTION
Based on https://github.com/free-audio/clap/compare/1.1.1...1.1.2

The only non-documentation change is the addition of explicit calling convention, and clap-sys already had this.