### PR TITLE
Define a macro for CStr literals

### DIFF
--- a/src/ext/audio_ports.rs
+++ b/src/ext/audio_ports.rs
@@ -1,13 +1,12 @@
-use crate::{host::*, id::*, plugin::*, string_sizes::*};
+use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_AUDIO_PORTS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.audio-ports\0") };
+pub const CLAP_EXT_AUDIO_PORTS: &CStr = cstr!("clap.audio-ports");
 
-pub const CLAP_PORT_MONO: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"mono\0") };
-pub const CLAP_PORT_STEREO: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"stereo\0") };
+pub const CLAP_PORT_MONO: &CStr = cstr!("mono");
+pub const CLAP_PORT_STEREO: &CStr = cstr!("stereo");
 
 pub const CLAP_AUDIO_PORT_IS_MAIN: u32 = 1 << 0;
 pub const CLAP_AUDIO_PORT_SUPPORTS_64BITS: u32 = 1 << 1;

--- a/src/ext/audio_ports_config.rs
+++ b/src/ext/audio_ports_config.rs
@@ -1,13 +1,11 @@
 use crate::ext::audio_ports::*;
-use crate::{host::*, id::*, plugin::*, string_sizes::*};
+use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_AUDIO_PORTS_CONFIG: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.audio-ports-config\0") };
-pub const CLAP_EXT_AUDIO_PORTS_CONFIG_INFO: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.audio-ports-config-info/draft-0\0") };
+pub const CLAP_EXT_AUDIO_PORTS_CONFIG: &CStr = cstr!("clap.audio-ports-config");
+pub const CLAP_EXT_AUDIO_PORTS_CONFIG_INFO: &CStr = cstr!("clap.audio-ports-config-info/draft-0");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/ambisonic.rs
+++ b/src/ext/draft/ambisonic.rs
@@ -1,12 +1,10 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_AMBISONIC: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.ambisonic.draft/2\0") };
+pub const CLAP_EXT_AMBISONIC: &CStr = cstr!("clap.ambisonic.draft/2");
 
-pub const CLAP_PORT_AMBISONIC: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"ambisonic\0") };
+pub const CLAP_PORT_AMBISONIC: &CStr = cstr!("ambisonic");
 
 pub const CLAP_AMBISONIC_FUMA: u32 = 0;
 pub const CLAP_AMBISONIC_ACN: u32 = 1;

--- a/src/ext/draft/audio_ports_activation.rs
+++ b/src/ext/draft/audio_ports_activation.rs
@@ -1,9 +1,8 @@
-use crate::plugin::*;
+use crate::{cstr, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_AUDIO_PORTS_ACTIVATION: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.audio-ports-activation/draft-1\0") };
+pub const CLAP_EXT_AUDIO_PORTS_ACTIVATION: &CStr = cstr!("clap.audio-ports-activation/draft-1");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/check_for_update.rs
+++ b/src/ext/draft/check_for_update.rs
@@ -1,10 +1,9 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_CHECK_FOR_UPDATE: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.check_for_update.draft/0\0") };
+pub const CLAP_EXT_CHECK_FOR_UPDATE: &CStr = cstr!("clap.check_for_update.draft/0");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/configurable_audio_ports.rs
+++ b/src/ext/draft/configurable_audio_ports.rs
@@ -1,9 +1,8 @@
-use crate::plugin::*;
+use crate::{cstr, plugin::*};
 
 use std::ffi::{c_char, CStr};
 
-pub const CLAP_EXT_CONFIGURABLE_AUDIO_PORTS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.configurable-audio-ports.draft0\0") };
+pub const CLAP_EXT_CONFIGURABLE_AUDIO_PORTS: &CStr = cstr!("clap.configurable-audio-ports.draft0");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/context_menu.rs
+++ b/src/ext/draft/context_menu.rs
@@ -1,10 +1,9 @@
-use crate::{host::*, id::*, plugin::*};
+use crate::{cstr, host::*, id::*, plugin::*};
 
 use std::ffi::{c_void, CStr};
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_CONTEXT_MENU: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.context-menu.draft/0\0") };
+pub const CLAP_EXT_CONTEXT_MENU: &CStr = cstr!("clap.context-menu.draft/0");
 
 pub const CLAP_CONTEXT_MENU_TARGET_KIND_GLOBAL: u32 = 0;
 pub const CLAP_CONTEXT_MENU_TARGET_KIND_PARAM: u32 = 1;

--- a/src/ext/draft/cv.rs
+++ b/src/ext/draft/cv.rs
@@ -1,10 +1,10 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_CV: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.cv.draft/0\0") };
+pub const CLAP_EXT_CV: &CStr = cstr!("clap.cv.draft/0");
 
-pub const CLAP_PORT_CV: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"cv\0") };
+pub const CLAP_PORT_CV: &CStr = cstr!("cv");
 
 pub const CLAP_CV_VALUE: u32 = 0;
 pub const CLAP_CV_GATE: u32 = 1;

--- a/src/ext/draft/extensible_audio_ports.rs
+++ b/src/ext/draft/extensible_audio_ports.rs
@@ -1,9 +1,8 @@
-use crate::plugin::*;
+use crate::{cstr, plugin::*};
 
 use std::ffi::{c_char, c_void, CStr};
 
-pub const CLAP_EXT_EXTENSIBLE_AUDIO_PORTS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.extensible-audio-ports.draft0\0") };
+pub const CLAP_EXT_EXTENSIBLE_AUDIO_PORTS: &CStr = cstr!("clap.extensible-audio-ports.draft0");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/midi_mappings.rs
+++ b/src/ext/draft/midi_mappings.rs
@@ -1,9 +1,8 @@
-use crate::{host::*, id::*, plugin::*};
+use crate::{cstr, host::*, id::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_MIDI_MAPPINGS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.midi-mappings.draft/0\0") };
+pub const CLAP_EXT_MIDI_MAPPINGS: &CStr = cstr!("clap.midi-mappings.draft/0");
 
 pub const CLAP_MIDI_MAPPING_CC7: clap_midi_mapping_type = 0;
 pub const CLAP_MIDI_MAPPING_CC14: clap_midi_mapping_type = 1;

--- a/src/ext/draft/param_indication.rs
+++ b/src/ext/draft/param_indication.rs
@@ -1,10 +1,9 @@
-use crate::{color::*, id::*, plugin::*};
+use crate::{color::*, cstr, id::*, plugin::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_PARAM_INDICATION: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.param-indication.draft/4\0") };
+pub const CLAP_EXT_PARAM_INDICATION: &CStr = cstr!("clap.param-indication.draft/4");
 
 pub const CLAP_PARAM_INDICATION_AUTOMATION_NONE: u32 = 0;
 pub const CLAP_PARAM_INDICATION_AUTOMATION_PRESENT: u32 = 1;

--- a/src/ext/draft/preset_load.rs
+++ b/src/ext/draft/preset_load.rs
@@ -1,11 +1,10 @@
 use crate::factory::draft::preset_discovery::*;
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_PRESET_LOAD: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.preset-load.draft/2\0") };
+pub const CLAP_EXT_PRESET_LOAD: &CStr = cstr!("clap.preset-load.draft/2");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/remote_controls.rs
+++ b/src/ext/draft/remote_controls.rs
@@ -1,10 +1,9 @@
-use crate::{host::*, id::*, plugin::*, string_sizes::*};
+use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_REMOTE_CONTROLS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.remote-controls.draft/2\0") };
+pub const CLAP_EXT_REMOTE_CONTROLS: &CStr = cstr!("clap.remote-controls.draft/2");
 
 pub const CLAP_REMOTE_CONTROLS_COUNT: usize = 8;
 

--- a/src/ext/draft/resource_directory.rs
+++ b/src/ext/draft/resource_directory.rs
@@ -1,10 +1,9 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_RESOURCE_DIRECTORY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.resource-directory.draft/0\0") };
+pub const CLAP_EXT_RESOURCE_DIRECTORY: &CStr = cstr!("clap.resource-directory.draft/0");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/state_context.rs
+++ b/src/ext/draft/state_context.rs
@@ -1,9 +1,8 @@
-use crate::{plugin::*, stream::*};
+use crate::{cstr, plugin::*, stream::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_STATE_CONTEXT: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.state-context.draft/1\0") };
+pub const CLAP_EXT_STATE_CONTEXT: &CStr = cstr!("clap.state-context.draft/1");
 
 pub const CLAP_STATE_CONTEXT_FOR_DUPLICATE: clap_plugin_state_context_type = 1;
 pub const CLAP_STATE_CONTEXT_FOR_PRESET: clap_plugin_state_context_type = 2;

--- a/src/ext/draft/surround.rs
+++ b/src/ext/draft/surround.rs
@@ -1,11 +1,10 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_SURROUND: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.surround.draft/3\0") };
+pub const CLAP_EXT_SURROUND: &CStr = cstr!("clap.surround.draft/3");
 
-pub const CLAP_PORT_SURROUND: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"surround\0") };
+pub const CLAP_PORT_SURROUND: &CStr = cstr!("surround");
 
 pub const CLAP_SURROUND_FL: u32 = 0;
 pub const CLAP_SURROUND_FR: u32 = 1;

--- a/src/ext/draft/track_info.rs
+++ b/src/ext/draft/track_info.rs
@@ -1,10 +1,9 @@
-use crate::{color::*, host::*, plugin::*, string_sizes::*};
+use crate::{color::*, cstr, host::*, plugin::*, string_sizes::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_TRACK_INFO: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.track-info.draft/1\0") };
+pub const CLAP_EXT_TRACK_INFO: &CStr = cstr!("clap.track-info.draft/1");
 
 pub const CLAP_TRACK_INFO_HAS_TRACK_NAME: u64 = 1 << 0;
 pub const CLAP_TRACK_INFO_HAS_TRACK_COLOR: u64 = 1 << 1;

--- a/src/ext/draft/transport_control.rs
+++ b/src/ext/draft/transport_control.rs
@@ -1,9 +1,8 @@
-use crate::{fixedpoint::*, host::*};
+use crate::{cstr, fixedpoint::*, host::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_TRANSPORT_CONTROL: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.transport-control.draft/0\0") };
+pub const CLAP_EXT_TRANSPORT_CONTROL: &CStr = cstr!("clap.transport-control.draft/0");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/draft/triggers.rs
+++ b/src/ext/draft/triggers.rs
@@ -1,11 +1,10 @@
-use crate::{events::*, host::*, id::*, plugin::*, string_sizes::*};
+use crate::{cstr, events::*, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_TRIGGERS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.triggers.draft/0\0") };
+pub const CLAP_EXT_TRIGGERS: &CStr = cstr!("clap.triggers.draft/0");
 
 pub const CLAP_TRIGGER_IS_AUTOMATABLE_PER_NOTE_ID: clap_trigger_info_flags = 1 << 0;
 pub const CLAP_TRIGGER_IS_AUTOMATABLE_PER_KEY: clap_trigger_info_flags = 1 << 1;

--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -1,10 +1,9 @@
-use crate::{events::*, host::*, id::*, plugin::*, string_sizes::*};
+use crate::{cstr, events::*, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_TUNING: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.tuning.draft/2\0") };
+pub const CLAP_EXT_TUNING: &CStr = cstr!("clap.tuning.draft/2");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/event_registry.rs
+++ b/src/ext/event_registry.rs
@@ -1,10 +1,9 @@
-use crate::host::*;
+use crate::{cstr, host::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_EVENT_REGISTRY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.event-registry\0") };
+pub const CLAP_EXT_EVENT_REGISTRY: &CStr = cstr!("clap.event-registry");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/gui.rs
+++ b/src/ext/gui.rs
@@ -1,16 +1,15 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::{c_void, CStr};
 use std::fmt::Debug;
 use std::os::raw::{c_char, c_ulong};
 
-pub const CLAP_EXT_GUI: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.gui\0") };
+pub const CLAP_EXT_GUI: &CStr = cstr!("clap.gui");
 
-pub const CLAP_WINDOW_API_WIN32: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"win32\0") };
-pub const CLAP_WINDOW_API_COCOA: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"cocoa\0") };
-pub const CLAP_WINDOW_API_X11: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"x11\0") };
-pub const CLAP_WINDOW_API_WAYLAND: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"wayland\0") };
+pub const CLAP_WINDOW_API_WIN32: &CStr = cstr!("win32");
+pub const CLAP_WINDOW_API_COCOA: &CStr = cstr!("cocoa");
+pub const CLAP_WINDOW_API_X11: &CStr = cstr!("x11");
+pub const CLAP_WINDOW_API_WAYLAND: &CStr = cstr!("wayland");
 
 pub type clap_hwnd = *mut c_void;
 pub type clap_nsview = *mut c_void;

--- a/src/ext/latency.rs
+++ b/src/ext/latency.rs
@@ -1,9 +1,8 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_LATENCY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.latency\0") };
+pub const CLAP_EXT_LATENCY: &CStr = cstr!("clap.latency");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/log.rs
+++ b/src/ext/log.rs
@@ -1,9 +1,9 @@
-use crate::host::*;
+use crate::{cstr, host::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_LOG: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.log\0") };
+pub const CLAP_EXT_LOG: &CStr = cstr!("clap.log");
 
 pub const CLAP_LOG_DEBUG: clap_log_severity = 0;
 pub const CLAP_LOG_INFO: clap_log_severity = 1;

--- a/src/ext/note_name.rs
+++ b/src/ext/note_name.rs
@@ -1,10 +1,9 @@
-use crate::{host::*, plugin::*, string_sizes::*};
+use crate::{cstr, host::*, plugin::*, string_sizes::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_NOTE_NAME: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.note-name\0") };
+pub const CLAP_EXT_NOTE_NAME: &CStr = cstr!("clap.note-name");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/note_ports.rs
+++ b/src/ext/note_ports.rs
@@ -1,10 +1,9 @@
-use crate::{host::*, id::*, plugin::*, string_sizes::*};
+use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_NOTE_PORTS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.note-ports\0") };
+pub const CLAP_EXT_NOTE_PORTS: &CStr = cstr!("clap.note-ports");
 
 pub const CLAP_NOTE_DIALECT_CLAP: clap_note_dialect = 1 << 0;
 pub const CLAP_NOTE_DIALECT_MIDI: clap_note_dialect = 1 << 1;

--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -1,10 +1,10 @@
-use crate::{events::*, host::*, id::*, plugin::*, string_sizes::*};
+use crate::{cstr, events::*, host::*, id::*, plugin::*, string_sizes::*};
 
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_EXT_PARAMS: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.params\0") };
+pub const CLAP_EXT_PARAMS: &CStr = cstr!("clap.params");
 
 pub const CLAP_PARAM_IS_STEPPED: clap_param_info_flags = 1 << 0;
 pub const CLAP_PARAM_IS_PERIODIC: clap_param_info_flags = 1 << 1;

--- a/src/ext/posix_fd_support.rs
+++ b/src/ext/posix_fd_support.rs
@@ -1,9 +1,8 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_POSIX_FD_SUPPORT: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.posix-fd-support\0") };
+pub const CLAP_EXT_POSIX_FD_SUPPORT: &CStr = cstr!("clap.posix-fd-support");
 
 pub const CLAP_POSIX_FD_READ: clap_posix_fd_flags = 1 << 0;
 pub const CLAP_POSIX_FD_WRITE: clap_posix_fd_flags = 1 << 1;

--- a/src/ext/render.rs
+++ b/src/ext/render.rs
@@ -1,8 +1,8 @@
-use crate::plugin::*;
+use crate::{cstr, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_RENDER: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.render\0") };
+pub const CLAP_EXT_RENDER: &CStr = cstr!("clap.render");
 
 pub const CLAP_RENDER_REALTIME: clap_plugin_render_mode = 0;
 pub const CLAP_RENDER_OFFLINE: clap_plugin_render_mode = 1;

--- a/src/ext/state.rs
+++ b/src/ext/state.rs
@@ -1,8 +1,8 @@
-use crate::{host::*, plugin::*, stream::*};
+use crate::{cstr, host::*, plugin::*, stream::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_STATE: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.state\0") };
+pub const CLAP_EXT_STATE: &CStr = cstr!("clap.state");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/tail.rs
+++ b/src/ext/tail.rs
@@ -1,8 +1,8 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_TAIL: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.tail\0") };
+pub const CLAP_EXT_TAIL: &CStr = cstr!("clap.tail");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/thread_check.rs
+++ b/src/ext/thread_check.rs
@@ -1,9 +1,8 @@
-use crate::host::*;
+use crate::{cstr, host::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_THREAD_CHECK: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.thread-check\0") };
+pub const CLAP_EXT_THREAD_CHECK: &CStr = cstr!("clap.thread-check");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/thread_pool.rs
+++ b/src/ext/thread_pool.rs
@@ -1,9 +1,8 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_THREAD_POOL: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.thread-pool\0") };
+pub const CLAP_EXT_THREAD_POOL: &CStr = cstr!("clap.thread-pool");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/timer_support.rs
+++ b/src/ext/timer_support.rs
@@ -1,9 +1,8 @@
-use crate::{host::*, id::*, plugin::*};
+use crate::{cstr, host::*, id::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_TIMER_SUPPORT: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.timer-support\0") };
+pub const CLAP_EXT_TIMER_SUPPORT: &CStr = cstr!("clap.timer-support");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/voice_info.rs
+++ b/src/ext/voice_info.rs
@@ -1,9 +1,8 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 
-pub const CLAP_EXT_VOICE_INFO: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.voice-info\0") };
+pub const CLAP_EXT_VOICE_INFO: &CStr = cstr!("clap.voice-info");
 
 pub const CLAP_VOICE_INFO_SUPPORTS_OVERLAPPING_NOTES: u64 = 1 << 0;
 

--- a/src/factory/draft/plugin_invalidation.rs
+++ b/src/factory/draft/plugin_invalidation.rs
@@ -1,8 +1,10 @@
+use crate::cstr;
+
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
 pub const CLAP_PLUGIN_INVALIDATION_FACTORY_ID: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.plugin-invalidation-factory/draft0\0") };
+    cstr!("clap.plugin-invalidation-factory/draft0");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/factory/draft/preset_discovery.rs
+++ b/src/factory/draft/preset_discovery.rs
@@ -1,10 +1,9 @@
-use crate::version::*;
+use crate::{cstr, version::*};
 
 use std::ffi::{c_void, CStr};
 use std::os::raw::c_char;
 
-pub const CLAP_PRESET_DISCOVERY_FACTORY_ID: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.preset-discovery-factory/draft-2\0") };
+pub const CLAP_PRESET_DISCOVERY_FACTORY_ID: &CStr = cstr!("clap.preset-discovery-factory/draft-2");
 
 pub const CLAP_PRESET_DISCOVERY_LOCATION_FILE: clap_preset_discovery_location_kind = 0;
 pub const CLAP_PRESET_DISCOVERY_LOCATION_PLUGIN: clap_preset_discovery_location_kind = 1;

--- a/src/factory/plugin_factory.rs
+++ b/src/factory/plugin_factory.rs
@@ -1,10 +1,9 @@
-use crate::{host::*, plugin::*};
+use crate::{cstr, host::*, plugin::*};
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-pub const CLAP_PLUGIN_FACTORY_ID: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"clap.plugin-factory\0") };
+pub const CLAP_PLUGIN_FACTORY_ID: &CStr = cstr!("clap.plugin-factory");
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,11 @@ pub mod process;
 pub mod stream;
 pub mod string_sizes;
 pub mod version;
+
+/// Define a null terminated `CStr` literal.
+macro_rules! cstr {
+    ($str:literal) => {
+        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes()) }
+    };
+}
+pub(crate) use cstr;

--- a/src/plugin_features.rs
+++ b/src/plugin_features.rs
@@ -1,93 +1,56 @@
+use crate::cstr;
+
 use std::ffi::CStr;
 
-pub const CLAP_PLUGIN_FEATURE_INSTRUMENT: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"instrument\0") };
+pub const CLAP_PLUGIN_FEATURE_INSTRUMENT: &CStr = cstr!("instrument");
 
-pub const CLAP_PLUGIN_FEATURE_AUDIO_EFFECT: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"audio-effect\0") };
+pub const CLAP_PLUGIN_FEATURE_AUDIO_EFFECT: &CStr = cstr!("audio-effect");
 
-pub const CLAP_PLUGIN_FEATURE_NOTE_EFFECT: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"note-effect\0") };
+pub const CLAP_PLUGIN_FEATURE_NOTE_EFFECT: &CStr = cstr!("note-effect");
 
-pub const CLAP_PLUGIN_FEATURE_NOTE_DETECTOR: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"note-detector\0") };
+pub const CLAP_PLUGIN_FEATURE_NOTE_DETECTOR: &CStr = cstr!("note-detector");
 
-pub const CLAP_PLUGIN_FEATURE_ANALYZER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"analyzer\0") };
+pub const CLAP_PLUGIN_FEATURE_ANALYZER: &CStr = cstr!("analyzer");
 
-pub const CLAP_PLUGIN_FEATURE_SYNTHESIZER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"synthesizer\0") };
-pub const CLAP_PLUGIN_FEATURE_SAMPLER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"sampler\0") };
-pub const CLAP_PLUGIN_FEATURE_DRUM: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"drum\0") };
-pub const CLAP_PLUGIN_FEATURE_DRUM_MACHINE: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"drum-machine\0") };
+pub const CLAP_PLUGIN_FEATURE_SYNTHESIZER: &CStr = cstr!("synthesizer");
+pub const CLAP_PLUGIN_FEATURE_SAMPLER: &CStr = cstr!("sampler");
+pub const CLAP_PLUGIN_FEATURE_DRUM: &CStr = cstr!("drum");
+pub const CLAP_PLUGIN_FEATURE_DRUM_MACHINE: &CStr = cstr!("drum-machine");
 
-pub const CLAP_PLUGIN_FEATURE_FILTER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"filter\0") };
-pub const CLAP_PLUGIN_FEATURE_PHASER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"phaser\0") };
-pub const CLAP_PLUGIN_FEATURE_EQUALIZER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"equalizer\0") };
-pub const CLAP_PLUGIN_FEATURE_DEESSER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"de-esser\0") };
-pub const CLAP_PLUGIN_FEATURE_PHASE_VOCODER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"phase-vocoder\0") };
-pub const CLAP_PLUGIN_FEATURE_GRANULAR: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"granular\0") };
-pub const CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"frequency-shifter\0") };
-pub const CLAP_PLUGIN_FEATURE_PITCH_SHIFTER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"pitch-shifter\0") };
+pub const CLAP_PLUGIN_FEATURE_FILTER: &CStr = cstr!("filter");
+pub const CLAP_PLUGIN_FEATURE_PHASER: &CStr = cstr!("phaser");
+pub const CLAP_PLUGIN_FEATURE_EQUALIZER: &CStr = cstr!("equalizer");
+pub const CLAP_PLUGIN_FEATURE_DEESSER: &CStr = cstr!("de-esser");
+pub const CLAP_PLUGIN_FEATURE_PHASE_VOCODER: &CStr = cstr!("phase-vocoder");
+pub const CLAP_PLUGIN_FEATURE_GRANULAR: &CStr = cstr!("granular");
+pub const CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER: &CStr = cstr!("frequency-shifter");
+pub const CLAP_PLUGIN_FEATURE_PITCH_SHIFTER: &CStr = cstr!("pitch-shifter");
 
-pub const CLAP_PLUGIN_FEATURE_DISTORTION: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"distortion\0") };
-pub const CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"transient-shaper\0") };
-pub const CLAP_PLUGIN_FEATURE_COMPRESSOR: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"compressor\0") };
-pub const CLAP_PLUGIN_FEATURE_EXPANDER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"expander\0") };
-pub const CLAP_PLUGIN_FEATURE_GATE: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"gate\0") };
-pub const CLAP_PLUGIN_FEATURE_LIMITER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"limiter\0") };
+pub const CLAP_PLUGIN_FEATURE_DISTORTION: &CStr = cstr!("distortion");
+pub const CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER: &CStr = cstr!("transient-shaper");
+pub const CLAP_PLUGIN_FEATURE_COMPRESSOR: &CStr = cstr!("compressor");
+pub const CLAP_PLUGIN_FEATURE_EXPANDER: &CStr = cstr!("expander");
+pub const CLAP_PLUGIN_FEATURE_GATE: &CStr = cstr!("gate");
+pub const CLAP_PLUGIN_FEATURE_LIMITER: &CStr = cstr!("limiter");
 
-pub const CLAP_PLUGIN_FEATURE_FLANGER: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"flanger\0") };
-pub const CLAP_PLUGIN_FEATURE_CHORUS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"chorus\0") };
-pub const CLAP_PLUGIN_FEATURE_DELAY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"delay\0") };
-pub const CLAP_PLUGIN_FEATURE_REVERB: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"reverb\0") };
+pub const CLAP_PLUGIN_FEATURE_FLANGER: &CStr = cstr!("flanger");
+pub const CLAP_PLUGIN_FEATURE_CHORUS: &CStr = cstr!("chorus");
+pub const CLAP_PLUGIN_FEATURE_DELAY: &CStr = cstr!("delay");
+pub const CLAP_PLUGIN_FEATURE_REVERB: &CStr = cstr!("reverb");
 
-pub const CLAP_PLUGIN_FEATURE_TREMOLO: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"tremolo\0") };
-pub const CLAP_PLUGIN_FEATURE_GLITCH: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"glitch\0") };
+pub const CLAP_PLUGIN_FEATURE_TREMOLO: &CStr = cstr!("tremolo");
+pub const CLAP_PLUGIN_FEATURE_GLITCH: &CStr = cstr!("glitch");
 
-pub const CLAP_PLUGIN_FEATURE_UTILITY: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"utility\0") };
-pub const CLAP_PLUGIN_FEATURE_PITCH_CORRECTION: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"pitch-correction\0") };
-pub const CLAP_PLUGIN_FEATURE_RESTORATION: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"restoration\0") };
+pub const CLAP_PLUGIN_FEATURE_UTILITY: &CStr = cstr!("utility");
+pub const CLAP_PLUGIN_FEATURE_PITCH_CORRECTION: &CStr = cstr!("pitch-correction");
+pub const CLAP_PLUGIN_FEATURE_RESTORATION: &CStr = cstr!("restoration");
 
-pub const CLAP_PLUGIN_FEATURE_MULTI_EFFECTS: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"multi-effects\0") };
+pub const CLAP_PLUGIN_FEATURE_MULTI_EFFECTS: &CStr = cstr!("multi-effects");
 
-pub const CLAP_PLUGIN_FEATURE_MIXING: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"mixing\0") };
-pub const CLAP_PLUGIN_FEATURE_MASTERING: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"mastering\0") };
+pub const CLAP_PLUGIN_FEATURE_MIXING: &CStr = cstr!("mixing");
+pub const CLAP_PLUGIN_FEATURE_MASTERING: &CStr = cstr!("mastering");
 
-pub const CLAP_PLUGIN_FEATURE_MONO: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"mono\0") };
-pub const CLAP_PLUGIN_FEATURE_STEREO: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"stereo\0") };
-pub const CLAP_PLUGIN_FEATURE_SURROUND: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"surround\0") };
-pub const CLAP_PLUGIN_FEATURE_AMBISONIC: &CStr =
-    unsafe { CStr::from_bytes_with_nul_unchecked(b"ambisonic\0") };
+pub const CLAP_PLUGIN_FEATURE_MONO: &CStr = cstr!("mono");
+pub const CLAP_PLUGIN_FEATURE_STEREO: &CStr = cstr!("stereo");
+pub const CLAP_PLUGIN_FEATURE_SURROUND: &CStr = cstr!("surround");
+pub const CLAP_PLUGIN_FEATURE_AMBISONIC: &CStr = cstr!("ambisonic");


### PR DESCRIPTION
This removes a lot of boilerplate and it makes it impossible to accidentally forget the trailing null byte.

Marked as a draft since it builds on top of #26.