### PR TITLE
update for CLAP 1.1.10

### DIFF
--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -22,6 +22,7 @@ pub const CLAP_PARAM_IS_MODULATABLE_PER_KEY: clap_param_info_flags = 1 << 12;
 pub const CLAP_PARAM_IS_MODULATABLE_PER_CHANNEL: clap_param_info_flags = 1 << 13;
 pub const CLAP_PARAM_IS_MODULATABLE_PER_PORT: clap_param_info_flags = 1 << 14;
 pub const CLAP_PARAM_REQUIRES_PROCESS: clap_param_info_flags = 1 << 15;
+pub const CLAP_PARAM_IS_ENUM: clap_param_info_flags = 1 << 16;
 
 pub type clap_param_info_flags = u32;
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -10,7 +10,7 @@ pub struct clap_version {
 
 pub const CLAP_VERSION_MAJOR: u32 = 1;
 pub const CLAP_VERSION_MINOR: u32 = 1;
-pub const CLAP_VERSION_REVISION: u32 = 9;
+pub const CLAP_VERSION_REVISION: u32 = 10;
 
 pub const CLAP_VERSION: clap_version = clap_version {
     major: CLAP_VERSION_MAJOR,


### PR DESCRIPTION
Corresponding diff in the CLAP repository: https://github.com/free-audio/clap/compare/1.1.9..1.1.10