### PR TITLE
specify branches for "push" and "pull_request" workflow triggers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,12 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      master
+  pull_request:
+    branches:
+      master
 
 jobs:
   build:


### PR DESCRIPTION
Without this, both the "push" and "pull_request" workflows are triggered for pull requests.