### PR TITLE
fix MSRV in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clap-sys"
 version = "0.4.0"
-rust-version = "1.59"
+rust-version = "1.64"
 authors = ["Micah Johnston <micah@glowcoil.com>", "Robbert van der Helm <mail@robbertvanderhelm.nl"]
 edition = "2021"
 description = "Rust bindings for the CLAP audio plugin API"


### PR DESCRIPTION
Several files make use of `std::ffi::c_char` (rather than `std::os::raw::c_char`), which was added in Rust 1.64.