### PR TITLE
update for CLAP 1.2.1

### DIFF
--- a/src/ext/draft/mod.rs
+++ b/src/ext/draft/mod.rs
@@ -3,3 +3,4 @@ pub mod resource_directory;
 pub mod transport_control;
 pub mod triggers;
 pub mod tuning;
+pub mod undo;

--- a/src/ext/draft/undo.rs
+++ b/src/ext/draft/undo.rs
@@ -1,0 +1,71 @@
+use crate::{cstr, host::*, id::*, plugin::*};
+
+use std::ffi::{c_char, c_void, CStr};
+
+pub const CLAP_EXT_UNDO: &CStr = cstr!("clap.undo/2");
+
+pub const CLAP_UNDO_IS_WITHIN_CHANGE: clap_undo_context_flags = 1 << 0;
+
+pub type clap_undo_context_flags = u64;
+
+pub const CLAP_UNDO_DELTA_PROPERTIES_HAS_DELTA: clap_undo_delta_properties_flags = 1 << 0;
+pub const CLAP_UNDO_DELTA_PROPERTIES_IS_PERSISTENT: clap_undo_delta_properties_flags = 1 << 1;
+
+pub type clap_undo_delta_properties_flags = u64;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct clap_undo_delta_properties {
+    pub flags: clap_undo_delta_properties_flags,
+    pub format_version: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct clap_plugin_undo {
+    pub get_delta_properties: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            properties: *mut clap_undo_delta_properties,
+        ),
+    >,
+    pub can_use_delta_format_version:
+        Option<unsafe extern "C" fn(plugin: *const clap_plugin, format_version: clap_id) -> bool>,
+    pub apply_delta: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            format_version: clap_id,
+            delta: *const c_void,
+            delta_size: usize,
+        ) -> bool,
+    >,
+    pub set_context_info: Option<
+        unsafe extern "C" fn(
+            plugin: *const clap_plugin,
+            flags: clap_undo_context_flags,
+            undo_name: *const c_char,
+            redo_name: *const c_char,
+        ),
+    >,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct clap_host_undo {
+    pub begin_change: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub cancel_change: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub change_made: Option<
+        unsafe extern "C" fn(
+            host: *const clap_host,
+            name: *const c_char,
+            redo_delta: *const c_void,
+            redo_delta_size: usize,
+            undo_delta: *const c_void,
+            undo_delta_size: usize,
+        ),
+    >,
+    pub undo: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub redo: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    pub set_context_info_subscription:
+        Option<unsafe extern "C" fn(host: *const clap_host, is_subscribed: bool)>,
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -10,7 +10,7 @@ pub struct clap_version {
 
 pub const CLAP_VERSION_MAJOR: u32 = 1;
 pub const CLAP_VERSION_MINOR: u32 = 2;
-pub const CLAP_VERSION_REVISION: u32 = 0;
+pub const CLAP_VERSION_REVISION: u32 = 1;
 
 pub const CLAP_VERSION: clap_version = clap_version {
     major: CLAP_VERSION_MAJOR,


### PR DESCRIPTION
Corresponding diff in the CLAP repository: https://github.com/free-audio/clap/compare/1.2.0..1.2.1