### PR TITLE
Make the crate no_std

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,6 +1,6 @@
 use crate::version::*;
 
-use std::ffi::{c_char, c_void};
+use core::ffi::{c_char, c_void};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,6 @@
 use crate::{fixedpoint::*, id::*};
 
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/ext/ambisonic.rs
+++ b/src/ext/ambisonic.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_AMBISONIC: &CStr = cstr!("clap.ambisonic/3");
 pub const CLAP_EXT_AMBISONIC_COMPAT: &CStr = cstr!("clap.ambisonic.draft/3");

--- a/src/ext/audio_ports.rs
+++ b/src/ext/audio_ports.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_AUDIO_PORTS: &CStr = cstr!("clap.audio-ports");
 

--- a/src/ext/audio_ports_activation.rs
+++ b/src/ext/audio_ports_activation.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_AUDIO_PORTS_ACTIVATION: &CStr = cstr!("clap.audio-ports-activation/2");
 pub const CLAP_EXT_AUDIO_PORTS_ACTIVATION_COMPAT: &CStr =

--- a/src/ext/audio_ports_config.rs
+++ b/src/ext/audio_ports_config.rs
@@ -1,7 +1,7 @@
 use crate::ext::audio_ports::*;
 use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_AUDIO_PORTS_CONFIG: &CStr = cstr!("clap.audio-ports-config");
 pub const CLAP_EXT_AUDIO_PORTS_CONFIG_INFO: &CStr = cstr!("clap.audio-ports-config-info/1");

--- a/src/ext/configurable_audio_ports.rs
+++ b/src/ext/configurable_audio_ports.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, plugin::*};
 
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 pub const CLAP_EXT_CONFIGURABLE_AUDIO_PORTS: &CStr = cstr!("clap.configurable-audio-ports/1");
 pub const CLAP_EXT_CONFIGURABLE_AUDIO_PORTS_COMPAT: &CStr =

--- a/src/ext/context_menu.rs
+++ b/src/ext/context_menu.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, id::*, plugin::*};
 
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 pub const CLAP_EXT_CONTEXT_MENU: &CStr = cstr!("clap.context-menu/1");
 pub const CLAP_EXT_CONTEXT_MENU_COMPAT: &CStr = cstr!("clap.context-menu.draft/0");

--- a/src/ext/draft/extensible_audio_ports.rs
+++ b/src/ext/draft/extensible_audio_ports.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, plugin::*};
 
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 pub const CLAP_EXT_EXTENSIBLE_AUDIO_PORTS: &CStr = cstr!("clap.extensible-audio-ports/1");
 

--- a/src/ext/draft/resource_directory.rs
+++ b/src/ext/draft/resource_directory.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_RESOURCE_DIRECTORY: &CStr = cstr!("clap.resource-directory/1");
 

--- a/src/ext/draft/transport_control.rs
+++ b/src/ext/draft/transport_control.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, fixedpoint::*, host::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_TRANSPORT_CONTROL: &CStr = cstr!("clap.transport-control/1");
 

--- a/src/ext/draft/triggers.rs
+++ b/src/ext/draft/triggers.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, events::*, host::*, id::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 pub const CLAP_EXT_TRIGGERS: &CStr = cstr!("clap.triggers/1");
 

--- a/src/ext/draft/tuning.rs
+++ b/src/ext/draft/tuning.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, events::*, host::*, id::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_TUNING: &CStr = cstr!("clap.tuning/2");
 

--- a/src/ext/draft/undo.rs
+++ b/src/ext/draft/undo.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, id::*, plugin::*};
 
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 pub const CLAP_EXT_UNDO: &CStr = cstr!("clap.undo/4");
 pub const CLAP_EXT_UNDO_CONTEXT: &CStr = cstr!("clap.undo_context/4");

--- a/src/ext/event_registry.rs
+++ b/src/ext/event_registry.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_EVENT_REGISTRY: &CStr = cstr!("clap.event-registry");
 

--- a/src/ext/gui.rs
+++ b/src/ext/gui.rs
@@ -1,7 +1,7 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::{c_char, c_ulong, c_void, CStr};
-use std::fmt::Debug;
+use core::ffi::{c_char, c_ulong, c_void, CStr};
+use core::fmt::Debug;
 
 pub const CLAP_EXT_GUI: &CStr = cstr!("clap.gui");
 
@@ -109,7 +109,7 @@ pub struct clap_host_gui {
 }
 
 impl Debug for clap_window_handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // We can't know which variant this actually is without supposed to be without checking the
         // `api` field in `clap_window`, but that cannot be done safely
         f.debug_struct("clap_window_handle").finish_non_exhaustive()

--- a/src/ext/latency.rs
+++ b/src/ext/latency.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_LATENCY: &CStr = cstr!("clap.latency");
 

--- a/src/ext/log.rs
+++ b/src/ext/log.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_LOG: &CStr = cstr!("clap.log");
 

--- a/src/ext/note_name.rs
+++ b/src/ext/note_name.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_NOTE_NAME: &CStr = cstr!("clap.note-name");
 

--- a/src/ext/note_ports.rs
+++ b/src/ext/note_ports.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_NOTE_PORTS: &CStr = cstr!("clap.note-ports");
 

--- a/src/ext/param_indication.rs
+++ b/src/ext/param_indication.rs
@@ -1,6 +1,6 @@
 use crate::{color::*, cstr, id::*, plugin::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_PARAM_INDICATION: &CStr = cstr!("clap.param-indication/4");
 pub const CLAP_EXT_PARAM_INDICATION_COMPAT: &CStr = cstr!("clap.param-indication.draft/4");

--- a/src/ext/params.rs
+++ b/src/ext/params.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, events::*, host::*, id::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 pub const CLAP_EXT_PARAMS: &CStr = cstr!("clap.params");
 

--- a/src/ext/posix_fd_support.rs
+++ b/src/ext/posix_fd_support.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_POSIX_FD_SUPPORT: &CStr = cstr!("clap.posix-fd-support");
 

--- a/src/ext/preset_load.rs
+++ b/src/ext/preset_load.rs
@@ -1,7 +1,7 @@
 use crate::factory::preset_discovery::*;
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_PRESET_LOAD: &CStr = cstr!("clap.preset-load/2");
 pub const CLAP_EXT_PRESET_LOAD_COMPAT: &CStr = cstr!("clap.preset-load.draft/2");

--- a/src/ext/remote_controls.rs
+++ b/src/ext/remote_controls.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, id::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_REMOTE_CONTROLS: &CStr = cstr!("clap.remote-controls/2");
 pub const CLAP_EXT_REMOTE_CONTROLS_COMPAT: &CStr = cstr!("clap.remote-controls.draft/2");

--- a/src/ext/render.rs
+++ b/src/ext/render.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_RENDER: &CStr = cstr!("clap.render");
 

--- a/src/ext/state.rs
+++ b/src/ext/state.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*, stream::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_STATE: &CStr = cstr!("clap.state");
 

--- a/src/ext/state_context.rs
+++ b/src/ext/state_context.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, plugin::*, stream::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_STATE_CONTEXT: &CStr = cstr!("clap.state-context/2");
 

--- a/src/ext/surround.rs
+++ b/src/ext/surround.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_SURROUND: &CStr = cstr!("clap.surround/4");
 pub const CLAP_EXT_SURROUND_COMPAT: &CStr = cstr!("clap.surround.draft/4");

--- a/src/ext/tail.rs
+++ b/src/ext/tail.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_TAIL: &CStr = cstr!("clap.tail");
 

--- a/src/ext/thread_check.rs
+++ b/src/ext/thread_check.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_THREAD_CHECK: &CStr = cstr!("clap.thread-check");
 

--- a/src/ext/thread_pool.rs
+++ b/src/ext/thread_pool.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_THREAD_POOL: &CStr = cstr!("clap.thread-pool");
 

--- a/src/ext/timer_support.rs
+++ b/src/ext/timer_support.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, id::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_TIMER_SUPPORT: &CStr = cstr!("clap.timer-support");
 

--- a/src/ext/track_info.rs
+++ b/src/ext/track_info.rs
@@ -1,6 +1,6 @@
 use crate::{color::*, cstr, host::*, plugin::*, string_sizes::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_EXT_TRACK_INFO: &CStr = cstr!("clap.track-info/1");
 pub const CLAP_EXT_TRACK_INFO_COMPAT: &CStr = cstr!("clap.track-info.draft/1");

--- a/src/ext/voice_info.rs
+++ b/src/ext/voice_info.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_EXT_VOICE_INFO: &CStr = cstr!("clap.voice-info");
 

--- a/src/factory/draft/plugin_invalidation.rs
+++ b/src/factory/draft/plugin_invalidation.rs
@@ -1,6 +1,6 @@
 use crate::cstr;
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_PLUGIN_INVALIDATION_FACTORY_ID: &CStr = cstr!("clap.plugin-invalidation-factory/1");
 

--- a/src/factory/draft/plugin_state_converter.rs
+++ b/src/factory/draft/plugin_state_converter.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 use crate::{
     cstr,

--- a/src/factory/plugin_factory.rs
+++ b/src/factory/plugin_factory.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, host::*, plugin::*};
 
-use std::ffi::{c_char, CStr};
+use core::ffi::{c_char, CStr};
 
 pub const CLAP_PLUGIN_FACTORY_ID: &CStr = cstr!("clap.plugin-factory");
 

--- a/src/factory/preset_discovery.rs
+++ b/src/factory/preset_discovery.rs
@@ -1,6 +1,6 @@
 use crate::{cstr, timestamp::*, universal_plugin_id::*, version::*};
 
-use std::ffi::{c_char, c_void, CStr};
+use core::ffi::{c_char, c_void, CStr};
 
 pub const CLAP_PRESET_DISCOVERY_FACTORY_ID: &CStr = cstr!("clap.preset-discovery-factory/2");
 pub const CLAP_PRESET_DISCOVERY_FACTORY_ID_COMPAT: &CStr =

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,6 @@
 use crate::version::*;
 
-use std::ffi::{c_char, c_void};
+use core::ffi::{c_char, c_void};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,3 +1,3 @@
 pub type clap_id = u32;
 
-pub const CLAP_INVALID_ID: clap_id = std::u32::MAX;
+pub const CLAP_INVALID_ID: clap_id = u32::MAX;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 #![allow(non_camel_case_types)]
 
 pub mod ext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub mod version;
 /// Define a null terminated `CStr` literal.
 macro_rules! cstr {
     ($str:literal) => {
-        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes()) }
+        unsafe { core::ffi::CStr::from_bytes_with_nul_unchecked(concat!($str, "\0").as_bytes()) }
     };
 }
 pub(crate) use cstr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), no_std)]
 #![allow(non_camel_case_types)]
 
 pub mod ext;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,6 @@
 use crate::{process::*, version::*};
 
-use std::ffi::{c_char, c_void};
+use core::ffi::{c_char, c_void};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/plugin_features.rs
+++ b/src/plugin_features.rs
@@ -1,6 +1,6 @@
 use crate::cstr;
 
-use std::ffi::CStr;
+use core::ffi::CStr;
 
 pub const CLAP_PLUGIN_FEATURE_INSTRUMENT: &CStr = cstr!("instrument");
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/universal_plugin_id.rs
+++ b/src/universal_plugin_id.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_char;
+use core::ffi::c_char;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
The motivation behind this PR is to make the crate usable in more environments, i.e. embedded.

The crate is in fact already `no_std` by design, so the changes were entirely done automatically by running: 

`cargo clippy --fix -- -Wclippy::std_instead_of_core` 
